### PR TITLE
Be more like rioxarray in CF attribute handling

### DIFF
--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -183,15 +183,14 @@ def assign_crs(
 
 
 def xr_coords(
-    gbox: GeoBox, with_crs: Union[bool, str] = True
+    gbox: GeoBox, crs_coord_name: Optional[str] = "spatial_ref"
 ) -> Dict[Hashable, xarray.DataArray]:
     """
     Dictionary of Coordinates in xarray format.
 
-    :param with_crs:
-       By default includes netcdf/cf style CRS Coordinate
-       with default name 'spatial_ref', if with_crs is a string then treat
-       the string as a name of the coordinate. To disable pass in ``False``.
+    :param crs_coord_name:
+       Use custom name for CRS coordinate, default is "spatial_ref".
+       Set to ``None`` to not generate CRS coordinate at all.
 
     Returns
     =======
@@ -201,11 +200,6 @@ def xr_coords(
     where names are either ``y,x`` for projected or ``latitude, longitude`` for geographic.
 
     """
-    spatial_ref = "spatial_ref"
-    if isinstance(with_crs, str):
-        spatial_ref = with_crs
-        with_crs = True
-
     attrs = {}
     crs = gbox.crs
     if crs is not None:
@@ -216,8 +210,8 @@ def xr_coords(
         for name, coord in gbox.coordinates.items()
     }
 
-    if with_crs and crs is not None:
-        coords[spatial_ref] = _mk_crs_coord(crs, spatial_ref)
+    if crs_coord_name is not None and crs is not None:
+        coords[crs_coord_name] = _mk_crs_coord(crs, crs_coord_name)
 
     return coords
 

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -124,7 +124,6 @@ def _mk_crs_coord(crs: CRS, name: str = "spatial_ref") -> xarray.DataArray:
     # pylint: disable=protected-access
 
     cf = crs.proj.to_cf()
-    cf.setdefault("grid_mapping_name", "??")
     epsg = 0 if crs.epsg is None else crs.epsg
     crs_wkt = cf.get("crs_wkt", None) or crs.wkt
 

--- a/odc/geo/crs.py
+++ b/odc/geo/crs.py
@@ -107,7 +107,7 @@ class CRS:
 
     @property
     def wkt(self) -> str:
-        return self.to_wkt(version=WktVersion.WKT1_GDAL)
+        return self.to_wkt()
 
     def to_epsg(self) -> Optional[int]:
         """

--- a/odc/geo/testutils.py
+++ b/odc/geo/testutils.py
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Callable, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -193,7 +193,7 @@ def gen_test_image_xy(
 
 
 def xr_zeros(
-    gbox: GeoBox, dtype="float64", with_crs: Union[str, bool] = True
+    gbox: GeoBox, dtype="float64", crs_coord_name: Optional[str] = "spatial_ref"
 ) -> xr.DataArray:
     """
     Construct geo-registered xarray from a :py:class:`~odc.geo.geobox.GeoBox`.
@@ -202,7 +202,7 @@ def xr_zeros(
     :return: :class:py:`xarray.DataArray` filled with zeros
     """
     data = np.zeros(gbox.shape, dtype=dtype)
-    cc = xr_coords(gbox, with_crs=with_crs)
+    cc = xr_coords(gbox, crs_coord_name=crs_coord_name)
     ydim, xdim, grid_mapping = list(cc)
     xx = xr.DataArray(data=data, coords=cc, dims=(ydim, xdim))
     xx.encoding["grid_mapping"] = grid_mapping

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -163,7 +163,8 @@ def test_assign_crs(xx_epsg4326: xr.DataArray):
 
     # non-cf complaint CRS
     yy = xx.odc.assign_crs("epsg:3857")
-    assert yy.spatial_ref.attrs["grid_mapping_name"] == "??"
+    assert yy.spatial_ref.attrs.get("grid_mapping_name") is None
+    assert yy.odc.crs == "epsg:3857"
 
 
 def test_assign_crs_ds(xx_epsg4326: xr.DataArray):
@@ -177,7 +178,8 @@ def test_assign_crs_ds(xx_epsg4326: xr.DataArray):
 
     # non-cf complaint CRS
     yy = xx.odc.assign_crs("epsg:3857")
-    assert yy.spatial_ref.attrs["grid_mapping_name"] == "??"
+    assert yy.spatial_ref.attrs.get("grid_mapping_name") is None
+    assert yy.odc.crs == "epsg:3857"
 
 
 def test_corrupt_inputs(xx_epsg4326: xr.DataArray):

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -190,14 +190,21 @@ def test_corrupt_inputs(xx_epsg4326: xr.DataArray):
         # it will still get it from attributes
         assert xx.odc.uncached.crs == "epsg:4326"
 
+    # missing spatial_ref, but have crs_wkt
+    xx = xx_epsg4326.copy()
+    xx.spatial_ref.attrs.pop("spatial_ref")
+    assert xx.odc.crs == "epsg:4326"
+
     # missing wkt text
     xx = xx_epsg4326.copy()
     xx.spatial_ref.attrs.pop("spatial_ref")
+    xx.spatial_ref.attrs.pop("crs_wkt")
     assert xx.odc.crs is None
 
     # bad CRS string
     xx = xx_epsg4326.copy()
     xx.spatial_ref.attrs["spatial_ref"] = "this is not a CRS!!!"
+    xx.spatial_ref.attrs["crs_wkt"] = "this is not a CRS!!!"
     assert xx.odc.crs is None
 
     # duplicated crs coords and no grid_mapping pointer

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -30,30 +30,30 @@ def test_geobox_xr_coords():
     w, h = 512, 256
     gbox = GeoBox(w, h, A, epsg3577)
 
-    cc = xr_coords(gbox, with_crs=False)
+    cc = xr_coords(gbox, crs_coord_name=None)
     assert list(cc) == ["y", "x"]
     assert cc["y"].shape == (gbox.shape[0],)
     assert cc["x"].shape == (gbox.shape[1],)
     assert "crs" in cc["y"].attrs
     assert "crs" in cc["x"].attrs
 
-    cc = xr_coords(gbox, with_crs=True)
+    cc = xr_coords(gbox)
     assert list(cc) == ["y", "x", "spatial_ref"]
     assert cc["spatial_ref"].shape == ()
     assert cc["spatial_ref"].attrs["spatial_ref"] == gbox.crs.wkt
     assert isinstance(cc["spatial_ref"].attrs["grid_mapping_name"], str)
 
-    # with_crs should be default True
-    assert list(xr_coords(gbox)) == list(xr_coords(gbox, with_crs=True))
+    # crs_coord_name should be default "spatial_ref"
+    assert list(xr_coords(gbox)) == list(xr_coords(gbox, crs_coord_name="spatial_ref"))
 
-    cc = xr_coords(gbox, with_crs="Albers")
+    cc = xr_coords(gbox, crs_coord_name="Albers")
     assert list(cc) == ["y", "x", "Albers"]
 
     # geographic CRS
     A = mkA(0, scale=(0.1, -0.1), translation=(10, 30))
     gbox = GeoBox(w, h, A, "epsg:4326")
 
-    cc = xr_coords(gbox, with_crs=True)
+    cc = xr_coords(gbox)
     assert list(cc) == ["latitude", "longitude", "spatial_ref"]
     assert cc["spatial_ref"].shape == ()
     assert cc["spatial_ref"].attrs["spatial_ref"] == gbox.crs.wkt
@@ -71,7 +71,7 @@ def test_xr_zeros(geobox_epsg4326: GeoBox):
     assert xx.spatial_ref.attrs["grid_mapping_name"] == "latitude_longitude"
 
     # check custom name for crs coordinate
-    xx = xr_zeros(gbox, dtype="uint16", with_crs="_crs")
+    xx = xr_zeros(gbox, dtype="uint16", crs_coord_name="_crs")
     assert "_crs" in xx.coords
     assert xx.encoding["grid_mapping"] == "_crs"
     assert (xx.values == 0).all()


### PR DESCRIPTION
netcdf/cf related changed:

- For CRSs supported by netdcf/cf convention include all attributes as reported by `pyproj.to_cf()` method.
- Look in `crs_wkt` attribute as well as in `spatial_ref` when looking for and interpreting CRS coordinate.


Some further API tweaking
- `with_crs="name"|True|False` argument to `xr_coord` was confusing, so it was replaced with
- `crs_coord_name="name"|None` where `None` is the same `False` was before, i.e. do not create a separate CRS coordinate.
- use default WKT format in `.wkt` property of the CRS object

