### PR TITLE
Refactor gridspec

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -116,10 +116,17 @@ odc.geo.gridspec
    :toctree: _api/
 
    GridSpec
+   GridSpec.from_sample_tile
+   GridSpec.web_tiles
+
    GridSpec.alignment
    GridSpec.dimensions
-   GridSpec.tile_coords
-   GridSpec.tile_geobox
    GridSpec.tile_shape
+
+   GridSpec.pt2idx
+   GridSpec.tile_geobox
+   GridSpec.__getitem__
    GridSpec.tiles
    GridSpec.tiles_from_geopolygon
+
+   GridSpec.geojson

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,6 +58,8 @@ odc.geo.geom
    :toctree: _api/
 
    Geometry
+   Geometry.to_crs
+   Geometry.geojson
    BoundingBox
 
    box

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -466,6 +466,43 @@ class Geometry:
 
         return geom._to_crs(crs)
 
+    def geojson(
+        self,
+        properties: Optional[Dict[str, Any]] = None,
+        simplify: float = 0.05,
+        resolution: Optional[float] = float("+inf"),
+        wrapdateline: bool = False,
+        **props,
+    ) -> Dict[str, Any]:
+        """
+        Render geometry to GeoJSON.
+
+        Convert geometry to ``ESPG:4326`` and wrap it in GeoJSON Feature with supplied properties.
+
+        :param properties:
+            Properties to include in the GeoJSON output.
+
+        :param simplify:
+            Tolerance in degrees for simplifying geometry after changing to lon/lat. Larger number
+            will result in a smaller (fewer points) and hence faster to display, but less precise
+            geometry. Default is ``0.05`` of a degree. To disable set to ``0``.
+
+        :param resolution:
+           When supplied, extra points will be added to the original geometry such that no segment
+           is longer than ``resolution`` units. Passed on to
+           :py:meth:`~odc.geo.geom.Geometry.to_crs`.
+
+        :param wrapdateline: Passed on to :py:meth:`~odc.geo.geom.Geometry.to_crs`
+
+        :return: GeoJSON Feature dictionary
+        """
+        gg = self.to_crs("epsg:4326", resolution=resolution, wrapdateline=wrapdateline)
+        if simplify > 0:
+            gg = gg.simplify(simplify)
+        if properties is None:
+            properties = dict(**props)
+        return {"type": "Feature", "geometry": gg.json, "properties": properties}
+
     def split(self, splitter: "Geometry") -> Iterable["Geometry"]:
         """shapely.ops.split"""
         if splitter.crs != self.crs:

--- a/odc/geo/gridspec.py
+++ b/odc/geo/gridspec.py
@@ -189,32 +189,23 @@ class GridSpec:
     def tiles_from_geopolygon(
         self,
         geopolygon: Geometry,
-        tile_buffer: Optional[Tuple[float, float]] = None,
         geobox_cache: Optional[dict] = None,
     ) -> Iterator[Tuple[Tuple[int, int], GeoBox]]:
         """
-        Query tiles overlapping with a gievn polygon.
+        Query tiles overlapping with a given polygon.
 
         Output is a sequence of ``tile_index``, :py:class:`odc.geo.geobox.GeoBox` tuples.
 
         :param geopolygon:
           Polygon to tile
-        :param tile_buffer:
-          Optional ``<float,float>`` tuple, (extra padding for the query in native units of this
-          GridSpec)
         :param geobox_cache:
           Optional cache to re-use geoboxes instead of creating new one each turn: iterator of grid
           cells with :py:class:`odc.geo.geobox.GeoBox` tiles
         """
         geopolygon = geopolygon.to_crs(self.crs)
         bbox = geopolygon.boundingbox
-        bbox = bbox.buffered(*tile_buffer) if tile_buffer else bbox
 
         for tile_index, tile_geobox in self.tiles(bbox, geobox_cache):
-            tile_geobox = (
-                tile_geobox.buffered(*tile_buffer) if tile_buffer else tile_geobox
-            )
-
             if intersects(tile_geobox.extent, geopolygon):
                 yield (tile_index, tile_geobox)
 

--- a/odc/geo/testutils.py
+++ b/odc/geo/testutils.py
@@ -22,7 +22,7 @@ epsg3857 = CRS("EPSG:3857")
 
 AlbersGS = GridSpec(
     crs=epsg3577,
-    tile_size=(100000.0, 100000.0),
+    tile_shape=(4000, 4000),
     resolution=(-25, 25),
     origin=(0.0, 0.0),
 )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,31 @@
+# odc-geo dependencies
+pyproj
+shapely
+rasterio
+xarray
+numpy
+cachetools
+
+# dev dependencies
+## linting tools
+autopep8
+autoflake
+black
+isort
+mock
+mypy
+pycodestyle
+pylint
+types-cachetools
+types-certifi
+shed
+
+## test
+pytest
+pytest-cov
+pytest-timeout
+
+## for docs
+sphinx
+sphinx_rtd_theme
+sphinx-autodoc-typehints

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -1230,6 +1230,24 @@ def test_lonlat_bounds():
     assert ll_bounds == approx(ll_bounds_projected)
 
 
+def test_geojson():
+    b = geom.box(0, 0, 10, 20, epsg4326)
+    gjson = b.geojson()
+    assert set(list(gjson)) == set(["type", "geometry", "properties"])
+    assert gjson["type"] == "Feature"
+    assert gjson["properties"] == {}
+    _b = geom.Geometry(gjson["geometry"], crs=epsg4326)
+    assert (b - _b).area < 1e-6
+
+    gjson = b.to_crs(epsg3857).geojson(region_code="33")
+    assert set(list(gjson)) == set(["type", "geometry", "properties"])
+    assert gjson["type"] == "Feature"
+    assert gjson["properties"] == {"region_code": "33"}
+
+    _b = geom.Geometry(gjson["geometry"], crs=epsg4326)
+    assert (b - _b).area < 1e-6
+
+
 @pytest.mark.xfail(
     True, reason="Bounds computation for large geometries in safe mode is broken"
 )


### PR DESCRIPTION
`GridSpec` is a handy class for large scale processing, but it's API in datacube had some issues. Fixing those. It does break backwards compatibility with what was in datacube, but I think it was broken enough not to keep it that way.

1. Use pixel units to define grid, not CRS units

Using tile size in CRS units + resolution leads to a possibility of fractional
pixel size. If tile size is 7m and pixel size is 3m, what should the size of a
tile be in pixels? Then there are problem of numeric precision. Defining grid in
pixels using integer sizes doesn't have this problem.

2. Negative tile sizes not allowed

Previously one could use negative tile size to reverse the order for grid
indexes. This is confusing and was not documented well.

Instead `fplix/flipy` parameters are introduced.

3. Adding more convenient construction options
   - From some tile geometry, index and shape
   - Direct support for slippy tiles regime

4. Adding geojson output for debugging and visualization
5. `origin` parameter is a point in CRS units, so changed order there to `x, y` rather than `y, x`, in `datacube` that parameter was not really used, and always defaulted to `0,0`.

Also adding geojson output to geometry and and gridspec classes, was needed for debugging and is generally useful.

### About X/Y, Y/X confusions

I almost started addressing it in this PR, but decided that won't be so great, but I still think a better solution is needed. Basically there are a lot of places where a tuple of two numbers is used to configure one of these things:

- Size in pixels (usually Y,X order, like numpy `.shape`)
- Size of a pixel (`resolution`), in Y,X order to match `.shape`, but it's way less obvious choice and X,Y could just as well be assumed by the user. There is also negative resolution for Y to indicate that pixel row index change in the opposite direction of pixel location along Y axis.
- Point in CRS space, usually in X, Y order.
- 2-d index, usually in Y,X order to match `ndarray` element access order

I think it's worthwhile refactoring those plain tuples out of the API entirely. It should be obvious at construction point what order you want to specify, and also at use site. I'm thinking something along these lines

```python
def some_method(..., resolution: Resolution):
    rr = resolution
    rx, ry = rr.xy
    ry, rx = rr.yx
    print(f"x: {rr.x}, y: {rr.y}")

some_method(..., resolution = xy_(10, -10))
some_method(..., resolution = yx_(-10, 10))
some_method(..., resolution = res_(x=10, y=-10))
```

idea is to decouple construction order from use order, while still allowing use of tuples on both sides but with clear demarcation of the order. Obviously having named access/construction should also be supported.

There should be a generic container for any two X,Y things of the same type, but also types for Shape/Point/Index/Size/Resolution.





