### PR TITLE
Change `.to_crs` default behaviour

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -40,7 +40,7 @@ odc.geo
 
    ixy_
    iyx_
- 
+
 
 odc.geo.crs
 ***********

--- a/docs/geobox.rst
+++ b/docs/geobox.rst
@@ -18,6 +18,7 @@ GeoBox
    GeoBox.resolution
    GeoBox.shape
    GeoBox.transform
+   GeoBox.affine
 
 Coordinate
 ==========

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -96,6 +96,8 @@ to perform higher precision transformation.
 * Constructor changed from accepting ``GeoBox(width, height, ...)`` to
   ``GeoBox(shape, ...)``, where ``shape=(nrows, ncols)``.
 
+* :py:attr:`~odc.geo.geobox.GeoBox.affine` is now read-only
+
 
 
 :py:class:`~odc.geo.gridspec.GridSpec`

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -71,21 +71,37 @@ Things like a pixel location or a tile index. Plain tuples are still accepted
 and order is API dependent. But it is now possible to indicate at call site what
 order is used with :py:func:`~odc.geo.ixy_` and :py:func:`~odc.geo.iyx_`.
 
+:py:meth:`~odc.geo.geom.Geometry.to_crs`
+========================================
+
+Changed default behaviour of :py:meth:`~odc.geo.geom.Geometry.to_crs` when
+``resolution=`` parameter is not supplied. Conversion to a different CRS no
+longer adds extra points to source geometry unless explicitly requested with
+the ``resolution=`` parameter.
+
+Previously ``resolution=`` defaulted to 100km for projected and 1 degree for
+geographic geometries. This default is rather arbitrary and probably not the
+right thing in most cases. It was also hard to disable as you needed to supply
+``resolution=float('+inf')``. I think the least surprising interface is to just
+transform the geometry point by point unless explicitly configured by the user
+to perform higher precision transformation.
 
 
 :py:class:`~odc.geo.geobox.GeoBox`
 ==================================
 
-* :py:class:`~odc.geo.geobox.GeoBox` now lives in a separate name-space from plain geometry classes
-* Constructor changed from accepting ``GeoBox(width, height, ...)`` to ``GeoBox(shape, ...)``, where
-  ``shape=(nrows, ncols)``.
+* :py:class:`~odc.geo.geobox.GeoBox` now lives in a separate name-space from
+  plain geometry classes
+
+* Constructor changed from accepting ``GeoBox(width, height, ...)`` to
+  ``GeoBox(shape, ...)``, where ``shape=(nrows, ncols)``.
 
 
 
 :py:class:`~odc.geo.gridspec.GridSpec`
 ======================================
 
-* Constructor changed
+* Constructor of :py:class:`~odc.geo.gridspec.GridSpec` changed
 
   * Tile size is now specified in pixels rather than CRS units
 

--- a/odc/geo/crs.py
+++ b/odc/geo/crs.py
@@ -2,7 +2,6 @@
 #
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
-import math
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
 
@@ -340,7 +339,7 @@ def crs_units_per_degree(
         lon2 = lon - step
 
     ll = geom.line([(lon, lat), (lon2, lat)], "EPSG:4326")
-    xy = ll.to_crs(crs, resolution=math.inf)
+    xy = ll.to_crs(crs)
 
     return xy.length / step
 

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -34,7 +34,6 @@ from .types import (
     resxy_,
     shape_,
     xy_,
-    yx_,
 )
 
 # pylint: disable=invalid-name
@@ -511,7 +510,7 @@ def zoom_to(gbox: GeoBox, shape: SomeShape) -> GeoBox:
     :returns:
       GeoBox covering the same region but with different number of pixels and therefore resolution.
     """
-    shape = yx_(shape)
+    shape = shape_(shape)
     sy, sx = (N / float(n) for N, n in zip(gbox.shape, shape.shape))
     A = gbox.affine * Affine.scale(sx, sy)
     return GeoBox(shape, A, gbox.crs)
@@ -563,12 +562,13 @@ class GeoboxTiles:
         :param box: source :py:class:`~odc.geo.GeoBox`
         :param tile_shape: Shape of sub-tiles in pixels ``(rows, cols)``
         """
-        tile_shape = yx_(tile_shape)
+        tile_shape = shape_(tile_shape)
         self._gbox = box
         self._tile_shape = tile_shape
-        self._shape = yx_(
+        ny, nx = (
             int(math.ceil(float(N) / n)) for N, n in zip(box.shape, tile_shape.shape)
         )
+        self._shape = shape_((ny, nx))
         self._cache: Dict[Index2d, GeoBox] = {}
 
     @property
@@ -579,7 +579,7 @@ class GeoboxTiles:
     @property
     def shape(self):
         """Number of tiles along each dimension."""
-        return self._shape.shape
+        return self._shape
 
     def _idx_to_slice(self, idx: Index2d) -> Tuple[slice, slice]:
         def _slice(i, N, n) -> slice:
@@ -648,7 +648,7 @@ class GeoboxTiles:
         # A maps from X,Y in meters to chunk index
         bbox = bbox.transform(A)
 
-        NY, NX = self.shape
+        NY, NX = self._shape
         xx = clamped_range(bbox.left, bbox.right, NX)
         yy = clamped_range(bbox.bottom, bbox.top, NY)
         return (yy, xx)

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -16,6 +16,7 @@ from shapely import geometry, ops
 from shapely.geometry import base
 
 from .crs import CRS, CRSMismatchError, MaybeCRS, SomeCRS, norm_crs, norm_crs_or_error
+from .types import SomeShape, shape_
 
 _BoundingBox = namedtuple("_BoundingBox", ("left", "bottom", "right", "top"))
 CoordList = List[Tuple[float, float]]
@@ -755,17 +756,19 @@ def box(
 
 
 def polygon_from_transform(
-    width: float, height: float, transform: Affine, crs: MaybeCRS
+    shape: SomeShape, transform: Affine, crs: MaybeCRS
 ) -> Geometry:
     """
-    Create a 2D Polygon from an affine transform.
+    Create a 2D Polygon from an affine transform and shape.
 
-    :param width:
-    :param height:
-    :param transform:
+    Useful for computing footprints of a geo-registered raster images.
+
+    :param shape: Shape of the raster in pixels
+    :param transform: Affine transfrom from pixel to CRS units
     :param crs: CRS
     """
-    points = [(0, 0), (0, height), (width, height), (width, 0), (0, 0)]
+    x1, y1 = shape_(shape).xy
+    points = [(0, 0), (0, y1), (x1, y1), (x1, 0), (0, 0)]
     transform.itransform(points)
     return polygon(points, crs=crs)
 


### PR DESCRIPTION
1. Unless explicitly requested by the user with `resolution=` parameter transform geometries without adding extra points
2. Further cleanups in Geobox classes
    - force read-only on `.affine`
    - delay geometry construction until first use
    - use `__slots__`
    - Use `Shape2d` for shape consistently, some places were missed in the previous refactor