### PR TITLE
Refactor overlap computation code

### DIFF
--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -8,15 +8,51 @@ Tools for dealing with ROIs (Regions of Interest).
 In this context ROI is a 2d slice of an image. For example a top left corner of 10 pixels square
 will have an ROI that can be constructed with :py:func:`numpy.s_` like this: ``s_[0:10, 0:10]``.
 """
-import collections.abc
+from collections import abc
+from typing import Optional, Protocol, Tuple, Union, overload
 
 import numpy as np
 
 from .math import align_down, align_up
+from .types import SomeShape, T, shape_
 
 # This is numeric code, short names make sense in this context, so disabling
 # "invalid name" checks for the whole file
 # pylint: disable=invalid-name
+
+# fmt: off
+class NormalizedSlice(Protocol):
+    """
+    Type for ``slice`` with start/stop set to integer values.
+    """
+    @property
+    def start(self) -> int: ...
+    @property
+    def stop(self) -> int: ...
+    @property
+    def step(self) -> Optional[int]: ...
+# fmt: on
+
+SomeSlice = Union[slice, int, NormalizedSlice]
+"""
+Slice index into ndarray or a single int.
+
+Single index is equivalent to ``slice(idx, idx+1)``.
+"""
+
+NdROI = Union[SomeSlice, Tuple[SomeSlice, ...]]
+"""
+Any dimensional slice into ndarray.
+
+This could be a single ``int`` or slice ``slice`` or a tuple of any number
+of those things.
+"""
+
+ROI = Tuple[SomeSlice, SomeSlice]
+"""2d slice into an image plane."""
+
+NormalizedROI = Tuple[NormalizedSlice, NormalizedSlice]
+"""Noramlized 2d slice into an image plane."""
 
 
 class WindowFromSlice:
@@ -28,7 +64,7 @@ class WindowFromSlice:
         if roi is None:
             return None
 
-        if not isinstance(roi, collections.abc.Sequence) or len(roi) != 2:
+        if not isinstance(roi, abc.Sequence) or len(roi) != 2:
             raise ValueError("Need 2d roi")
 
         row, col = roi
@@ -41,7 +77,7 @@ class WindowFromSlice:
 w_ = WindowFromSlice()
 
 
-def polygon_path(x, y=None):
+def polygon_path(x: np.ndarray, y: Optional[np.ndarray] = None) -> np.ndarray:
     """
     Points along axis aligned polygon.
 
@@ -75,14 +111,14 @@ def polygon_path(x, y=None):
     ).T
 
 
-def roi_boundary(roi, pts_per_side=2):
+def roi_boundary(roi: NormalizedROI, pts_per_side: int = 2) -> np.ndarray:
     """
     Get boundary points from a 2d roi.
 
     roi needs to be in the normalised form, i.e. no open-ended start/stop,
 
     :returns:
-      ``Nx2`` ``float32`` array of ``X,Y`` points on the perimeter of the envelope defined by ``roi``
+      ``Nx2 <float32>`` array of ``X,Y`` points on the perimeter of the envelope defined by ``roi``
 
     .. seealso:: :py:func:`~odc.geo.roi.roi_normalise`
     """
@@ -93,7 +129,7 @@ def roi_boundary(roi, pts_per_side=2):
     return polygon_path(xx, yy).T[:-1]
 
 
-def scaled_down_roi(roi, scale: int):
+def scaled_down_roi(roi: NormalizedROI, scale: int) -> NormalizedROI:
     """
     Compute ROI for a scaled down image.
 
@@ -103,10 +139,13 @@ def scaled_down_roi(roi, scale: int):
     :param scale: integer scale to get scaled down image
     :return: ROI in the scaled down image
     """
-    return tuple(slice(s.start // scale, align_up(s.stop, scale) // scale) for s in roi)
+    s1, s2 = (slice(s.start // scale, align_up(s.stop, scale) // scale) for s in roi)
+    return (s1, s2)
 
 
-def scaled_up_roi(roi, scale: int, shape=None):
+def scaled_up_roi(
+    roi: NormalizedROI, scale: int, shape: Optional[SomeShape] = None
+) -> NormalizedROI:
     """
     Compute ROI for a scaled up image.
 
@@ -114,17 +153,19 @@ def scaled_up_roi(roi, scale: int, shape=None):
 
     :param roi: ROI in the original image
     :param scale: integer scale to get scaled up image
-    :return: ROI in the scaled upimage
+    :param shape: Clamp to that shape is supplied
+    :return: ROI in the scaled up image
     """
-    roi = tuple(slice(s.start * scale, s.stop * scale) for s in roi)
+    s1, s2 = (slice(s.start * scale, s.stop * scale) for s in roi)
     if shape is not None:
-        roi = tuple(
-            slice(min(dim, s.start), min(dim, s.stop)) for s, dim in zip(roi, shape)
+        s1, s2 = (
+            slice(min(dim, s.start), min(dim, s.stop))
+            for s, dim in zip([s1, s2], shape_(shape))
         )
-    return roi
+    return (s1, s2)
 
 
-def scaled_down_shape(shape, scale: int):
+def scaled_down_shape(shape: Tuple[int, ...], scale: int) -> Tuple[int, ...]:
     """
     Compute shape of the overview image.
 
@@ -135,23 +176,32 @@ def scaled_down_shape(shape, scale: int):
     return tuple(align_up(s, scale) // scale for s in shape)
 
 
-def roi_shape(roi):
+def roi_shape(roi: NdROI) -> Tuple[int, ...]:
     """
     Shape of an array after cropping with ``roi``.
 
     Same as ``xx[roi].shape``.
     """
 
-    def slice_dim(s):
-        return s.stop if s.start is None else s.stop - s.start
+    def slice_dim(s: SomeSlice) -> int:
+        if isinstance(s, int):
+            return 1
+        _out = s.stop
+        if _out is None:
+            raise ValueError(
+                "Can't determine shape of the slice with open right-hand side."
+            )
+        if s.start is None:
+            return _out
+        return _out - s.start
 
-    if isinstance(roi, slice):
+    if not isinstance(roi, tuple):
         roi = (roi,)
 
     return tuple(slice_dim(s) for s in roi)
 
 
-def roi_is_empty(roi):
+def roi_is_empty(roi: NdROI) -> bool:
     """
     Check if ROI is "empty".
 
@@ -160,7 +210,7 @@ def roi_is_empty(roi):
     return any(d <= 0 for d in roi_shape(roi))
 
 
-def roi_is_full(roi, shape):
+def roi_is_full(roi: NdROI, shape: Union[int, Tuple[int, ...]]) -> bool:
     """
     Check if ROI covers the entire region.
 
@@ -168,17 +218,65 @@ def roi_is_full(roi, shape):
     :returns: ``False`` if ``roi`` actually crops an image
     """
 
-    def slice_full(s, n):
+    def slice_full(s: SomeSlice, n: int) -> bool:
+        if isinstance(s, int):
+            return n == 1
         return s.start in (0, None) and s.stop in (n, None)
 
-    if isinstance(roi, slice):
+    if not isinstance(roi, tuple):
         roi = (roi,)
+
+    if not isinstance(shape, tuple):
         shape = (shape,)
 
     return all(slice_full(s, n) for s, n in zip(roi, shape))
 
 
-def roi_normalise(roi, shape):
+def _fill_if_none(x: Optional[T], val_if_none: T) -> T:
+    return val_if_none if x is None else x
+
+
+def _norm_slice_or_error(s: SomeSlice) -> NormalizedSlice:
+    if isinstance(s, int):
+        start = s
+        stop = s + 1
+        step = None
+    else:
+        start = _fill_if_none(s.start, 0)
+
+        if s.stop is None:
+            raise ValueError("Can't process open ended slice")
+
+        stop = s.stop
+        step = s.step
+
+    if stop < 0 or start < 0:
+        raise ValueError("Can't process negative offset slice")
+
+    return slice(start, stop, step)
+
+
+def _norm_slice(s: SomeSlice, n: int) -> NormalizedSlice:
+    if isinstance(s, int):
+        return slice(s, s + 1)
+    start = _fill_if_none(s.start, 0)
+    stop = _fill_if_none(s.stop, n)
+    start, stop = (x if x >= 0 else n + x for x in (start, stop))
+    return slice(start, stop, s.step)
+
+
+# fmt: off
+@overload
+def roi_normalise(roi: SomeSlice, shape: Union[int, Tuple[int]]) -> NormalizedSlice: ...
+@overload
+def roi_normalise( roi: Tuple[SomeSlice, ...], shape: Tuple[int, ...]
+) -> Tuple[NormalizedSlice, ...]: ...
+# fmt: on
+
+
+def roi_normalise(
+    roi: NdROI, shape: Union[int, Tuple[int, ...]]
+) -> Union[NormalizedSlice, Tuple[NormalizedSlice, ...]]:
     """
     Normalise ROI.
 
@@ -195,42 +293,60 @@ def roi_normalise(roi, shape):
        np.s_[:3,  :-3], (10, 20) => np.s_[0:3, 0:17]
 
     """
+    if not isinstance(roi, abc.Sequence):
+        if isinstance(shape, abc.Sequence):
+            (shape,) = shape
+        return _norm_slice(roi, shape)
 
-    def fill_if_none(x, val_if_none):
-        return val_if_none if x is None else x
-
-    def norm_slice(s, n):
-        start = fill_if_none(s.start, 0)
-        stop = fill_if_none(s.stop, n)
-        start, stop = (x if x >= 0 else n + x for x in (start, stop))
-        return slice(start, stop, s.step)
-
-    if not isinstance(shape, collections.abc.Sequence):
+    if not isinstance(shape, abc.Sequence):
         shape = (shape,)
 
-    if isinstance(roi, slice):
-        return norm_slice(roi, shape[0])
-
-    return tuple(norm_slice(s, n) for s, n in zip(roi, shape))
+    return tuple(_norm_slice(s, n) for s, n in zip(roi, shape))
 
 
-def roi_pad(roi, pad, shape):
+# fmt: off
+@overload
+def roi_pad(roi: SomeSlice, pad: int, shape: int) -> NormalizedSlice: ...
+@overload
+def roi_pad(roi: Tuple[SomeSlice,...], pad: int, shape: Tuple[int, ...]) -> Tuple[NormalizedSlice, ...]: ...
+# fmt: on
+
+
+def roi_pad(
+    roi: NdROI, pad: int, shape: Union[int, Tuple[int, ...]]
+) -> Union[NormalizedSlice, Tuple[NormalizedSlice, ...]]:
     """
     Pad ROI on each side, with clamping.
 
     Returned ROI is guaranteed to be within ``(0,..) -> shape``.
     """
 
-    def pad_slice(s, n):
+    def pad_slice(s: SomeSlice, n: int) -> NormalizedSlice:
+        s = _norm_slice(s, n)
         return slice(max(0, s.start - pad), min(n, s.stop + pad))
 
-    if isinstance(roi, slice):
+    if not isinstance(roi, abc.Sequence):
+        if isinstance(shape, abc.Sequence):
+            (shape,) = shape
         return pad_slice(roi, shape)
+
+    if not isinstance(shape, abc.Sequence):
+        shape = (shape,)
 
     return tuple(pad_slice(s, n) for s, n in zip(roi, shape))
 
 
-def roi_intersect(a, b):
+# fmt: off
+@overload
+def roi_intersect(a: SomeSlice, b: SomeSlice) -> NormalizedSlice: ...
+@overload
+def roi_intersect(a: Tuple[SomeSlice, ...], b: Tuple[SomeSlice, ...]) -> Tuple[NormalizedSlice, ...]: ...
+# fmt: on
+
+
+def roi_intersect(
+    a: NdROI, b: NdROI
+) -> Union[NormalizedSlice, Tuple[NormalizedSlice, ...]]:
     """
     Compute intersection of two ROIs.
 
@@ -246,7 +362,10 @@ def roi_intersect(a, b):
 
     """
 
-    def slice_intersect(a, b):
+    def slice_intersect(a: SomeSlice, b: SomeSlice) -> NormalizedSlice:
+        a = _norm_slice_or_error(a)
+        b = _norm_slice_or_error(b)
+
         if a.stop < b.start:
             return slice(a.stop, a.stop)
         if a.start > b.stop:
@@ -257,29 +376,44 @@ def roi_intersect(a, b):
 
         return slice(_in, _out)
 
-    if isinstance(a, slice):
-        if not isinstance(b, slice):
-            b = b[0]
+    if not isinstance(a, abc.Sequence):
+        if isinstance(b, abc.Sequence):
+            (b,) = b
         return slice_intersect(a, b)
 
-    b = (b,) if isinstance(b, slice) else b
+    if not isinstance(b, abc.Sequence):
+        b = (b,)
 
     return tuple(slice_intersect(sa, sb) for sa, sb in zip(a, b))
 
 
-def roi_center(roi):
+# fmt: off
+@overload
+def roi_center(roi: SomeSlice) -> float: ...
+@overload
+def roi_center(roi: Tuple[SomeSlice, ...]) -> Tuple[float, ...]: ...
+# fmt: on
+
+
+def roi_center(roi: NdROI) -> Union[float, Tuple[float, ...]]:
     """Return center point of an ``roi``."""
 
-    def slice_center(s):
+    def slice_center(s: SomeSlice) -> float:
+        s = _norm_slice_or_error(s)
         return (s.start + s.stop) * 0.5
 
-    if isinstance(roi, slice):
+    if not isinstance(roi, abc.Sequence):
         return slice_center(roi)
 
     return tuple(slice_center(s) for s in roi)
 
 
-def roi_from_points(xy, shape, padding=0, align=None):
+def roi_from_points(
+    xy: np.ndarray,
+    shape: SomeShape,
+    padding: int = 0,
+    align: Optional[int] = None,
+) -> NormalizedROI:
     """
     Build ROI from sample points.
 
@@ -289,6 +423,7 @@ def roi_from_points(xy, shape, padding=0, align=None):
     Returned roi is clipped ``(0,0) --> shape``, so it won't stick outside of the
     valid region.
     """
+    shape = shape_(shape)
 
     def to_roi(*args):
         return tuple(slice(v[0], v[1]) for v in args)

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -1,5 +1,6 @@
 """Basic types."""
 from typing import (
+    Callable,
     Generic,
     Iterable,
     Iterator,
@@ -16,6 +17,8 @@ from typing import (
 MaybeInt = Optional[int]
 MaybeFloat = Optional[float]
 T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
 
 
 class XY(Generic[T]):
@@ -117,6 +120,12 @@ class XY(Generic[T]):
         if isinstance(x, int) and isinstance(y, int):
             return (x, y)
         raise ValueError("Expect (int, int) for wh")
+
+    def map(self, op: Callable[[T], T2]) -> "XY[T2]":
+        """
+        Apply function to x and y and return new XY value.
+        """
+        return xy_(op(self.x), op(self.y))
 
 
 class Resolution(XY[float]):

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import math
 import pickle
-from random import uniform
 
 import numpy as np
 import pytest
@@ -12,17 +11,9 @@ from affine import Affine
 from pytest import approx
 from shapely.errors import ShapelyDeprecationWarning
 
-from odc.geo import CRS, BoundingBox, CRSMismatchError, geom, resyx_, wh_
-from odc.geo._overlap import (
-    affine_from_pts,
-    compute_axis_overlap,
-    compute_reproject_roi,
-    decompose_rws,
-    get_scale_at_point,
-    native_pix_transform,
-)
+from odc.geo import CRS, BoundingBox, CRSMismatchError, geom, wh_
 from odc.geo.crs import norm_crs, norm_crs_or_error
-from odc.geo.geobox import GeoBox, _align_pix, _round_to_res, scaled_down_geobox
+from odc.geo.geobox import GeoBox, _align_pix, _round_to_res
 from odc.geo.geom import (
     bbox_union,
     chop_along_antimeridian,
@@ -32,7 +23,7 @@ from odc.geo.geom import (
     multigeom,
     projected_lon,
 )
-from odc.geo.math import apply_affine, is_affine_st, split_translation
+from odc.geo.math import apply_affine, split_translation
 from odc.geo.roi import (
     polygon_path,
     roi_boundary,
@@ -51,7 +42,6 @@ from odc.geo.roi import (
 )
 from odc.geo.testutils import (
     SAMPLE_WKT_WITHOUT_AUTHORITY,
-    AlbersGS,
     epsg3577,
     epsg3857,
     epsg4326,
@@ -889,212 +879,6 @@ def test_split_translation():
     tt(-1.5, 2.45, (-1, 2), (-0.5, 0.45))
 
 
-def get_diff(A, B):
-    return math.sqrt(sum((a - b) ** 2 for a, b in zip(A, B)))
-
-
-def test_affine_checks():
-    assert is_affine_st(mkA(scale=(1, 2), translation=(3, -10))) is True
-    assert is_affine_st(mkA(scale=(1, -2), translation=(-3, -10))) is True
-    assert is_affine_st(mkA(rot=0.1)) is False
-    assert is_affine_st(mkA(shear=0.4)) is False
-
-
-def test_affine_rsw():
-    def run_test(a, scale, shear=0, translation=(0, 0), tol=1e-8):
-        A = mkA(a, scale=scale, shear=shear, translation=translation)
-
-        R, W, S = decompose_rws(A)
-
-        assert get_diff(A, R * W * S) < tol
-        assert get_diff(S, mkA(0, scale)) < tol
-        assert get_diff(R, mkA(a, translation=translation)) < tol
-
-    for a in (0, 12, 45, 33, 67, 89, 90, 120, 170):
-        run_test(a, (1, 1))
-        run_test(a, (0.5, 2))
-        run_test(-a, (0.5, 2))
-
-        run_test(a, (1, 2))
-        run_test(-a, (1, 2))
-
-        run_test(a, (2, -1))
-        run_test(-a, (2, -1))
-
-    run_test(0, (3, 4), 10)
-    run_test(-33, (3, -1), 10, translation=(100, -333))
-
-
-def test_fit():
-    def run_test(A, n, tol=1e-5):
-        X = [(uniform(0, 1), uniform(0, 1)) for _ in range(n)]
-        Y = [A * x for x in X]
-        A_ = affine_from_pts(X, Y)
-
-        assert get_diff(A, A_) < tol
-
-    A = mkA(13, scale=(3, 4), shear=3, translation=(100, -3000))
-
-    run_test(A, 3)
-    run_test(A, 10)
-
-    run_test(mkA(), 3)
-    run_test(mkA(), 10)
-
-
-def test_scale_at_point():
-    def mk_transform(sx, sy):
-        A = mkA(37, scale=(sx, sy), translation=(2127, 93891))
-
-        def transofrom(pts):
-            return [A * x for x in pts]
-
-        return transofrom
-
-    tol = 1e-4
-    pt = (0, 0)
-    for sx, sy in [(3, 4), (0.4, 0.333)]:
-        tr = mk_transform(sx, sy)
-        sx_, sy_ = get_scale_at_point(pt, tr)
-        assert abs(sx - sx_) < tol
-        assert abs(sy - sy_) < tol
-
-        sx_, sy_ = get_scale_at_point(pt, tr, 0.1)
-        assert abs(sx - sx_) < tol
-        assert abs(sy - sy_) < tol
-
-
-def test_pix_transform():
-    pt = tuple(
-        int(x / 10) * 10
-        for x in geom.point(145, -35, epsg4326).to_crs(epsg3577).coords[0]
-    )
-
-    A = mkA(scale=(20, -20), translation=pt)
-
-    src = GeoBox((512, 1024), A, epsg3577)
-    dst = GeoBox.from_geopolygon(src.geographic_extent, resyx_(0.0001, -0.0001))
-
-    tr = native_pix_transform(src, dst)
-
-    pts_src = [(0, 0), (10, 20), (300, 200)]
-    pts_dst = tr(pts_src)
-    pts_src_ = tr.back(pts_dst)
-
-    np.testing.assert_almost_equal(pts_src, pts_src_)
-    assert tr.linear is None
-
-    # check identity transform
-    tr = native_pix_transform(src, src)
-
-    pts_src = [(0, 0), (10, 20), (300, 200)]
-    pts_dst = tr(pts_src)
-    pts_src_ = tr.back(pts_dst)
-
-    np.testing.assert_almost_equal(pts_src, pts_src_)
-    np.testing.assert_almost_equal(pts_src, pts_dst)
-    assert tr.linear is not None
-    assert tr.back.linear is not None
-    assert tr.back.back is tr
-
-    # check scale only change
-    tr = native_pix_transform(src, scaled_down_geobox(src, 2))
-    pts_dst = tr(pts_src)
-    pts_src_ = tr.back(pts_dst)
-
-    assert tr.linear is not None
-    assert tr.back.linear is not None
-    assert tr.back.back is tr
-
-    np.testing.assert_almost_equal(pts_dst, [(x / 2, y / 2) for (x, y) in pts_src])
-
-    np.testing.assert_almost_equal(pts_src, pts_src_)
-
-
-def test_compute_reproject_roi():
-    src = AlbersGS.tile_geobox((15, -40))
-    dst = GeoBox.from_geopolygon(
-        src.extent.to_crs(epsg3857).buffer(10), resolution=src.resolution
-    )
-
-    rr = compute_reproject_roi(src, dst)
-
-    assert rr.roi_src == np.s_[0 : src.height, 0 : src.width]
-    assert 0 < rr.scale < 1
-    assert rr.is_st is False
-    assert rr.transform.linear is None
-    assert rr.scale in rr.scale2
-
-    # check pure translation case
-    roi_ = np.s_[113:-100, 33:-10]
-    rr = compute_reproject_roi(src, src[roi_])
-    assert rr.roi_src == roi_normalise(roi_, src.shape)
-    assert rr.scale == 1
-    assert rr.is_st is True
-
-    rr = compute_reproject_roi(src, src[roi_], padding=0, align=0)
-    assert rr.roi_src == roi_normalise(roi_, src.shape)
-    assert rr.scale == 1
-    assert rr.scale2 == (1, 1)
-
-    # check pure translation case
-    roi_ = np.s_[113:-100, 33:-10]
-    rr = compute_reproject_roi(src, src[roi_], align=256)
-
-    assert rr.roi_src == np.s_[0 : src.height, 0 : src.width]
-    assert rr.scale == 1
-
-    roi_ = np.s_[113:-100, 33:-10]
-    rr = compute_reproject_roi(src, src[roi_])
-
-    assert rr.scale == 1
-    assert roi_shape(rr.roi_src) == roi_shape(rr.roi_dst)
-    assert roi_shape(rr.roi_dst) == src[roi_].shape
-
-
-def test_compute_reproject_roi_issue647():
-    """In some scenarios non-overlapping geoboxes will result in non-empty
-    `roi_dst` even though `roi_src` is empty.
-
-    Test this case separately.
-    """
-
-    src = GeoBox(
-        (10980, 10980), Affine(10, 0, 300000, 0, -10, 5900020), CRS("epsg:32756")
-    )
-
-    dst = GeoBox((976, 976), Affine(10, 0, 1730240, 0, -10, -4170240), CRS("EPSG:3577"))
-
-    assert src.extent.overlaps(dst.extent.to_crs(src.crs)) is False
-
-    rr = compute_reproject_roi(src, dst)
-
-    assert roi_is_empty(rr.roi_src)
-    assert roi_is_empty(rr.roi_dst)
-
-
-def test_compute_reproject_roi_issue1047():
-    """`compute_reproject_roi(geobox, geobox[roi])` sometimes returns
-    `src_roi != roi`, when `geobox` has (1) tiny pixels and (2) oddly
-    sized `alignment`.
-
-    Test this issue is resolved.
-    """
-    geobox = GeoBox(
-        (3000, 3000),
-        Affine(
-            0.00027778, 0.0, 148.72673054908861, 0.0, -0.00027778, -34.98825802556622
-        ),
-        "EPSG:4326",
-    )
-    src_roi = np.s_[2800:2810, 10:30]
-    rr = compute_reproject_roi(geobox, geobox[src_roi])
-
-    assert rr.is_st is True
-    assert rr.roi_src == src_roi
-    assert rr.roi_dst == np.s_[0:10, 0:20]
-
-
 def test_window_from_slice():
     s_ = np.s_
 
@@ -1106,53 +890,6 @@ def test_window_from_slice():
     for roi in [s_[:3], s_[:3, :4, :5], 0]:
         with pytest.raises(ValueError):
             w_[roi]
-
-
-def test_axis_overlap():
-    s_ = np.s_
-
-    # Source overlaps destination fully
-    #
-    # S: |<--------------->|
-    # D:      |<----->|
-    assert compute_axis_overlap(100, 20, 1, 10) == s_[10:30, 0:20]
-    assert compute_axis_overlap(100, 20, 2, 10) == s_[10:50, 0:20]
-    assert compute_axis_overlap(100, 20, 0.25, 10) == s_[10:15, 0:20]
-    assert compute_axis_overlap(100, 20, -1, 80) == s_[60:80, 0:20]
-    assert compute_axis_overlap(100, 20, -0.5, 50) == s_[40:50, 0:20]
-    assert compute_axis_overlap(100, 20, -2, 90) == s_[50:90, 0:20]
-
-    # Destination overlaps source fully
-    #
-    # S:      |<-------->|
-    # D: |<----------------->|
-    assert compute_axis_overlap(10, 100, 1, -10) == s_[0:10, 10:20]
-    assert compute_axis_overlap(10, 100, 2, -10) == s_[0:10, 5:10]
-    assert compute_axis_overlap(10, 100, 0.5, -10) == s_[0:10, 20:40]
-    assert compute_axis_overlap(10, 100, -1, 11) == s_[0:10, 1:11]
-
-    # Partial overlaps
-    #
-    # S: |<----------->|
-    # D:     |<----------->|
-    assert compute_axis_overlap(10, 10, 1, 3) == s_[3:10, 0:7]
-    assert compute_axis_overlap(10, 15, 1, 3) == s_[3:10, 0:7]
-
-    # S:     |<----------->|
-    # D: |<----------->|
-    assert compute_axis_overlap(10, 10, 1, -5) == s_[0:5, 5:10]
-    assert compute_axis_overlap(50, 10, 1, -5) == s_[0:5, 5:10]
-
-    # No overlaps
-    # S: |<--->|
-    # D:         |<--->|
-    assert compute_axis_overlap(10, 10, 1, 11) == s_[10:10, 0:0]
-    assert compute_axis_overlap(10, 40, 1, 11) == s_[10:10, 0:0]
-
-    # S:         |<--->|
-    # D: |<--->|
-    assert compute_axis_overlap(10, 10, 1, -11) == s_[0:0, 10:10]
-    assert compute_axis_overlap(40, 10, 1, -11) == s_[0:0, 10:10]
 
 
 def test_base_internals():

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -24,22 +24,6 @@ from odc.geo.geom import (
     projected_lon,
 )
 from odc.geo.math import apply_affine, split_translation
-from odc.geo.roi import (
-    polygon_path,
-    roi_boundary,
-    roi_center,
-    roi_from_points,
-    roi_intersect,
-    roi_is_empty,
-    roi_is_full,
-    roi_normalise,
-    roi_pad,
-    roi_shape,
-    scaled_down_roi,
-    scaled_down_shape,
-    scaled_up_roi,
-    w_,
-)
 from odc.geo.testutils import (
     SAMPLE_WKT_WITHOUT_AUTHORITY,
     epsg3577,
@@ -745,75 +729,6 @@ def test_mid_longitude():
     ) == approx(10)
 
 
-def test_polygon_path():
-    pp = polygon_path([0, 1])
-    assert pp.shape == (2, 5)
-    assert set(pp.ravel()) == {0, 1}
-
-    pp2 = polygon_path([0, 1], [0, 1])
-    assert (pp2 == pp).all()
-
-    pp = polygon_path([0, 1], [2, 3])
-    assert set(pp[0].ravel()) == {0, 1}
-    assert set(pp[1].ravel()) == {2, 3}
-
-
-def test_roi_tools():
-    s_ = np.s_
-
-    assert roi_shape(s_[2:4, 3:4]) == (2, 1)
-    assert roi_shape(s_[:4, :7]) == (4, 7)
-
-    assert roi_is_empty(s_[:4, :5]) is False
-    assert roi_is_empty(s_[1:1, :10]) is True
-    assert roi_is_empty(s_[7:3, :10]) is True
-
-    assert roi_is_empty(s_[:3]) is False
-    assert roi_is_empty(s_[4:4]) is True
-
-    assert roi_is_full(s_[:3], 3) is True
-    assert roi_is_full(s_[:3, 0:4], (3, 4)) is True
-    assert roi_is_full(s_[:, 0:4], (33, 4)) is True
-    assert roi_is_full(s_[1:3, 0:4], (3, 4)) is False
-    assert roi_is_full(s_[1:3, 0:4], (2, 4)) is False
-    assert roi_is_full(s_[0:4, 0:4], (3, 4)) is False
-
-    roi = s_[0:8, 0:4]
-    roi_ = scaled_down_roi(roi, 2)
-    assert roi_shape(roi_) == (4, 2)
-    assert scaled_down_roi(scaled_up_roi(roi, 3), 3) == roi
-
-    assert scaled_down_shape(roi_shape(roi), 2) == roi_shape(scaled_down_roi(roi, 2))
-
-    assert roi_shape(scaled_up_roi(roi, 10000, (40, 50))) == (40, 50)
-
-    assert roi_normalise(s_[3:4], 40) == s_[3:4]
-    assert roi_normalise(s_[:4], (40,)) == s_[0:4]
-    assert roi_normalise(s_[:], (40,)) == s_[0:40]
-    assert roi_normalise(s_[:-1], (3,)) == s_[0:2]
-    assert roi_normalise(s_[-2:-1, :], (10, 20)) == s_[8:9, 0:20]
-    assert roi_normalise(s_[-2:-1, :, 3:4], (10, 20, 100)) == s_[8:9, 0:20, 3:4]
-    assert roi_center(s_[0:3]) == 1.5
-    assert roi_center(s_[0:2, 0:6]) == (1, 3)
-
-    roi = s_[0:2, 4:13]
-    xy = roi_boundary(roi)
-
-    assert xy.shape == (4, 2)
-    assert roi_from_points(xy, (2, 13)) == roi
-
-    assert roi_intersect(roi, roi) == roi
-    assert roi_intersect(s_[0:3], s_[1:7]) == s_[1:3]
-    assert roi_intersect(s_[0:3], (s_[1:7],)) == s_[1:3]
-    assert roi_intersect((s_[0:3],), s_[1:7]) == (s_[1:3],)
-
-    assert roi_intersect(s_[4:7, 5:6], s_[0:1, 7:8]) == s_[4:4, 6:6]
-
-    assert roi_pad(s_[0:4], 1, 4) == s_[0:4]
-    assert roi_pad(s_[0:4, 1:5], 1, (4, 6)) == s_[0:4, 0:6]
-    assert roi_pad(s_[2:3, 1:5], 10, (7, 9)) == s_[0:7, 0:9]
-
-
 def test_apply_affine():
     A = mkA(rot=10, scale=(3, 1.3), translation=(-100, +2.3))
     xx, yy = np.meshgrid(np.arange(13), np.arange(11))
@@ -877,19 +792,6 @@ def test_split_translation():
     tt(-1.1, 2.8, (-1, 3), (-0.1, -0.2))
     tt(-1.9, 2.05, (-2, 2), (+0.1, 0.05))
     tt(-1.5, 2.45, (-1, 2), (-0.5, 0.45))
-
-
-def test_window_from_slice():
-    s_ = np.s_
-
-    assert w_[None] is None
-    assert w_[s_[:3, 4:5]] == ((0, 3), (4, 5))
-    assert w_[s_[0:3, :5]] == ((0, 3), (0, 5))
-    assert w_[list(s_[0:3, :5])] == ((0, 3), (0, 5))
-
-    for roi in [s_[:3], s_[:3, :4, :5], 0]:
-        with pytest.raises(ValueError):
-            w_[roi]
 
 
 def test_base_internals():

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -1,0 +1,276 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2020 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+import math
+from random import uniform
+
+import numpy as np
+from affine import Affine
+
+from odc.geo import CRS, geom, resyx_
+from odc.geo._overlap import (
+    affine_from_pts,
+    compute_axis_overlap,
+    compute_reproject_roi,
+    decompose_rws,
+    get_scale_at_point,
+    native_pix_transform,
+)
+from odc.geo.geobox import GeoBox, scaled_down_geobox
+from odc.geo.math import is_affine_st
+from odc.geo.roi import roi_is_empty, roi_normalise, roi_shape
+from odc.geo.testutils import AlbersGS, epsg3577, epsg3857, epsg4326, mkA
+
+
+def get_diff(A, B):
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(A, B)))
+
+
+def test_affine_checks():
+    assert is_affine_st(mkA(scale=(1, 2), translation=(3, -10))) is True
+    assert is_affine_st(mkA(scale=(1, -2), translation=(-3, -10))) is True
+    assert is_affine_st(mkA(rot=0.1)) is False
+    assert is_affine_st(mkA(shear=0.4)) is False
+
+
+def test_affine_rsw():
+    def run_test(a, scale, shear=0, translation=(0, 0), tol=1e-8):
+        A = mkA(a, scale=scale, shear=shear, translation=translation)
+
+        R, W, S = decompose_rws(A)
+
+        assert get_diff(A, R * W * S) < tol
+        assert get_diff(S, mkA(0, scale)) < tol
+        assert get_diff(R, mkA(a, translation=translation)) < tol
+
+    for a in (0, 12, 45, 33, 67, 89, 90, 120, 170):
+        run_test(a, (1, 1))
+        run_test(a, (0.5, 2))
+        run_test(-a, (0.5, 2))
+
+        run_test(a, (1, 2))
+        run_test(-a, (1, 2))
+
+        run_test(a, (2, -1))
+        run_test(-a, (2, -1))
+
+    run_test(0, (3, 4), 10)
+    run_test(-33, (3, -1), 10, translation=(100, -333))
+
+
+def test_fit():
+    def run_test(A, n, tol=1e-5):
+        X = [(uniform(0, 1), uniform(0, 1)) for _ in range(n)]
+        Y = [A * x for x in X]
+        A_ = affine_from_pts(X, Y)
+
+        assert get_diff(A, A_) < tol
+
+    A = mkA(13, scale=(3, 4), shear=3, translation=(100, -3000))
+
+    run_test(A, 3)
+    run_test(A, 10)
+
+    run_test(mkA(), 3)
+    run_test(mkA(), 10)
+
+
+def test_scale_at_point():
+    def mk_transform(sx, sy):
+        A = mkA(37, scale=(sx, sy), translation=(2127, 93891))
+
+        def transofrom(pts):
+            return [A * x for x in pts]
+
+        return transofrom
+
+    tol = 1e-4
+    pt = (0, 0)
+    for sx, sy in [(3, 4), (0.4, 0.333)]:
+        tr = mk_transform(sx, sy)
+        sx_, sy_ = get_scale_at_point(pt, tr)
+        assert abs(sx - sx_) < tol
+        assert abs(sy - sy_) < tol
+
+        sx_, sy_ = get_scale_at_point(pt, tr, 0.1)
+        assert abs(sx - sx_) < tol
+        assert abs(sy - sy_) < tol
+
+
+def test_pix_transform():
+    pt = tuple(
+        int(x / 10) * 10
+        for x in geom.point(145, -35, epsg4326).to_crs(epsg3577).coords[0]
+    )
+
+    A = mkA(scale=(20, -20), translation=pt)
+
+    src = GeoBox((512, 1024), A, epsg3577)
+    dst = GeoBox.from_geopolygon(src.geographic_extent, resyx_(0.0001, -0.0001))
+
+    tr = native_pix_transform(src, dst)
+
+    pts_src = [(0, 0), (10, 20), (300, 200)]
+    pts_dst = tr(pts_src)
+    pts_src_ = tr.back(pts_dst)
+
+    np.testing.assert_almost_equal(pts_src, pts_src_)
+    assert tr.linear is None
+
+    # check identity transform
+    tr = native_pix_transform(src, src)
+
+    pts_src = [(0, 0), (10, 20), (300, 200)]
+    pts_dst = tr(pts_src)
+    pts_src_ = tr.back(pts_dst)
+
+    np.testing.assert_almost_equal(pts_src, pts_src_)
+    np.testing.assert_almost_equal(pts_src, pts_dst)
+    assert tr.linear is not None
+    assert tr.back.linear is not None
+    assert tr.back.back is tr
+
+    # check scale only change
+    tr = native_pix_transform(src, scaled_down_geobox(src, 2))
+    pts_dst = tr(pts_src)
+    pts_src_ = tr.back(pts_dst)
+
+    assert tr.linear is not None
+    assert tr.back.linear is not None
+    assert tr.back.back is tr
+
+    np.testing.assert_almost_equal(pts_dst, [(x / 2, y / 2) for (x, y) in pts_src])
+
+    np.testing.assert_almost_equal(pts_src, pts_src_)
+
+
+def test_compute_reproject_roi():
+    src = AlbersGS.tile_geobox((15, -40))
+    dst = GeoBox.from_geopolygon(
+        src.extent.to_crs(epsg3857).buffer(10), resolution=src.resolution
+    )
+
+    rr = compute_reproject_roi(src, dst)
+
+    assert rr.roi_src == np.s_[0 : src.height, 0 : src.width]
+    assert 0 < rr.scale < 1
+    assert rr.is_st is False
+    assert rr.transform.linear is None
+    assert rr.scale in rr.scale2
+
+    # check pure translation case
+    roi_ = np.s_[113:-100, 33:-10]
+    rr = compute_reproject_roi(src, src[roi_])
+    assert rr.roi_src == roi_normalise(roi_, src.shape)
+    assert rr.scale == 1
+    assert rr.is_st is True
+
+    rr = compute_reproject_roi(src, src[roi_], padding=0, align=0)
+    assert rr.roi_src == roi_normalise(roi_, src.shape)
+    assert rr.scale == 1
+    assert rr.scale2 == (1, 1)
+
+    # check pure translation case
+    roi_ = np.s_[113:-100, 33:-10]
+    rr = compute_reproject_roi(src, src[roi_], align=256)
+
+    assert rr.roi_src == np.s_[0 : src.height, 0 : src.width]
+    assert rr.scale == 1
+
+    roi_ = np.s_[113:-100, 33:-10]
+    rr = compute_reproject_roi(src, src[roi_])
+
+    assert rr.scale == 1
+    assert roi_shape(rr.roi_src) == roi_shape(rr.roi_dst)
+    assert roi_shape(rr.roi_dst) == src[roi_].shape
+
+
+def test_compute_reproject_roi_issue647():
+    """In some scenarios non-overlapping geoboxes will result in non-empty
+    `roi_dst` even though `roi_src` is empty.
+
+    Test this case separately.
+    """
+
+    src = GeoBox(
+        (10980, 10980), Affine(10, 0, 300000, 0, -10, 5900020), CRS("epsg:32756")
+    )
+
+    dst = GeoBox((976, 976), Affine(10, 0, 1730240, 0, -10, -4170240), CRS("EPSG:3577"))
+
+    assert src.extent.overlaps(dst.extent.to_crs(src.crs)) is False
+
+    rr = compute_reproject_roi(src, dst)
+
+    assert roi_is_empty(rr.roi_src)
+    assert roi_is_empty(rr.roi_dst)
+
+
+def test_compute_reproject_roi_issue1047():
+    """`compute_reproject_roi(geobox, geobox[roi])` sometimes returns
+    `src_roi != roi`, when `geobox` has (1) tiny pixels and (2) oddly
+    sized `alignment`.
+
+    Test this issue is resolved.
+    """
+    geobox = GeoBox(
+        (3000, 3000),
+        Affine(
+            0.00027778, 0.0, 148.72673054908861, 0.0, -0.00027778, -34.98825802556622
+        ),
+        "EPSG:4326",
+    )
+    src_roi = np.s_[2800:2810, 10:30]
+    rr = compute_reproject_roi(geobox, geobox[src_roi])
+
+    assert rr.is_st is True
+    assert rr.roi_src == src_roi
+    assert rr.roi_dst == np.s_[0:10, 0:20]
+
+
+def test_axis_overlap():
+    s_ = np.s_
+
+    # Source overlaps destination fully
+    #
+    # S: |<--------------->|
+    # D:      |<----->|
+    assert compute_axis_overlap(100, 20, 1, 10) == s_[10:30, 0:20]
+    assert compute_axis_overlap(100, 20, 2, 10) == s_[10:50, 0:20]
+    assert compute_axis_overlap(100, 20, 0.25, 10) == s_[10:15, 0:20]
+    assert compute_axis_overlap(100, 20, -1, 80) == s_[60:80, 0:20]
+    assert compute_axis_overlap(100, 20, -0.5, 50) == s_[40:50, 0:20]
+    assert compute_axis_overlap(100, 20, -2, 90) == s_[50:90, 0:20]
+
+    # Destination overlaps source fully
+    #
+    # S:      |<-------->|
+    # D: |<----------------->|
+    assert compute_axis_overlap(10, 100, 1, -10) == s_[0:10, 10:20]
+    assert compute_axis_overlap(10, 100, 2, -10) == s_[0:10, 5:10]
+    assert compute_axis_overlap(10, 100, 0.5, -10) == s_[0:10, 20:40]
+    assert compute_axis_overlap(10, 100, -1, 11) == s_[0:10, 1:11]
+
+    # Partial overlaps
+    #
+    # S: |<----------->|
+    # D:     |<----------->|
+    assert compute_axis_overlap(10, 10, 1, 3) == s_[3:10, 0:7]
+    assert compute_axis_overlap(10, 15, 1, 3) == s_[3:10, 0:7]
+
+    # S:     |<----------->|
+    # D: |<----------->|
+    assert compute_axis_overlap(10, 10, 1, -5) == s_[0:5, 5:10]
+    assert compute_axis_overlap(50, 10, 1, -5) == s_[0:5, 5:10]
+
+    # No overlaps
+    # S: |<--->|
+    # D:         |<--->|
+    assert compute_axis_overlap(10, 10, 1, 11) == s_[10:10, 0:0]
+    assert compute_axis_overlap(10, 40, 1, 11) == s_[10:10, 0:0]
+
+    # S:         |<--->|
+    # D: |<--->|
+    assert compute_axis_overlap(10, 10, 1, -11) == s_[0:0, 10:10]
+    assert compute_axis_overlap(40, 10, 1, -11) == s_[0:0, 10:10]

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -1,0 +1,101 @@
+import numpy as np
+import pytest
+
+from odc.geo.roi import (
+    polygon_path,
+    roi_boundary,
+    roi_center,
+    roi_from_points,
+    roi_intersect,
+    roi_is_empty,
+    roi_is_full,
+    roi_normalise,
+    roi_pad,
+    roi_shape,
+    scaled_down_roi,
+    scaled_down_shape,
+    scaled_up_roi,
+    w_,
+)
+
+
+def test_roi_tools():
+    s_ = np.s_
+
+    assert roi_shape(s_[2:4, 3:4]) == (2, 1)
+    assert roi_shape(s_[:4, :7]) == (4, 7)
+
+    assert roi_is_empty(s_[:4, :5]) is False
+    assert roi_is_empty(s_[1:1, :10]) is True
+    assert roi_is_empty(s_[7:3, :10]) is True
+
+    assert roi_is_empty(s_[:3]) is False
+    assert roi_is_empty(s_[4:4]) is True
+
+    assert roi_is_full(s_[:3], 3) is True
+    assert roi_is_full(s_[:3, 0:4], (3, 4)) is True
+    assert roi_is_full(s_[:, 0:4], (33, 4)) is True
+    assert roi_is_full(s_[1:3, 0:4], (3, 4)) is False
+    assert roi_is_full(s_[1:3, 0:4], (2, 4)) is False
+    assert roi_is_full(s_[0:4, 0:4], (3, 4)) is False
+
+    roi = s_[0:8, 0:4]
+    roi_ = scaled_down_roi(roi, 2)
+    assert roi_shape(roi_) == (4, 2)
+    assert scaled_down_roi(scaled_up_roi(roi, 3), 3) == roi
+
+    assert scaled_down_shape(roi_shape(roi), 2) == roi_shape(scaled_down_roi(roi, 2))
+
+    assert roi_shape(scaled_up_roi(roi, 10000, (40, 50))) == (40, 50)
+
+    assert roi_normalise(s_[3:4], 40) == s_[3:4]
+    assert roi_normalise(s_[:4], (40,)) == s_[0:4]
+    assert roi_normalise(s_[:], (40,)) == s_[0:40]
+    assert roi_normalise(s_[:-1], (3,)) == s_[0:2]
+    assert roi_normalise(s_[-2:-1, :], (10, 20)) == s_[8:9, 0:20]
+    assert roi_normalise(s_[-2:-1, :, 3:4], (10, 20, 100)) == s_[8:9, 0:20, 3:4]
+    assert roi_center(s_[0:3]) == 1.5
+    assert roi_center(s_[0:2, 0:6]) == (1, 3)
+
+    roi = s_[0:2, 4:13]
+    xy = roi_boundary(roi)
+
+    assert xy.shape == (4, 2)
+    assert roi_from_points(xy, (2, 13)) == roi
+
+    assert roi_intersect(roi, roi) == roi
+    assert roi_intersect(s_[0:3], s_[1:7]) == s_[1:3]
+    assert roi_intersect(s_[0:3], (s_[1:7],)) == s_[1:3]
+    assert roi_intersect((s_[0:3],), s_[1:7]) == (s_[1:3],)
+
+    assert roi_intersect(s_[4:7, 5:6], s_[0:1, 7:8]) == s_[4:4, 6:6]
+
+    assert roi_pad(s_[0:4], 1, 4) == s_[0:4]
+    assert roi_pad(s_[0:4, 1:5], 1, (4, 6)) == s_[0:4, 0:6]
+    assert roi_pad(s_[2:3, 1:5], 10, (7, 9)) == s_[0:7, 0:9]
+
+
+def test_window_from_slice():
+    s_ = np.s_
+
+    assert w_[None] is None
+    assert w_[s_[:3, 4:5]] == ((0, 3), (4, 5))
+    assert w_[s_[0:3, :5]] == ((0, 3), (0, 5))
+    assert w_[list(s_[0:3, :5])] == ((0, 3), (0, 5))
+
+    for roi in [s_[:3], s_[:3, :4, :5], 0]:
+        with pytest.raises(ValueError):
+            _ = w_[roi]
+
+
+def test_polygon_path():
+    pp = polygon_path([0, 1])
+    assert pp.shape == (2, 5)
+    assert set(pp.ravel()) == {0, 1}
+
+    pp2 = polygon_path([0, 1], [0, 1])
+    assert (pp2 == pp).all()
+
+    pp = polygon_path([0, 1], [2, 3])
+    assert set(pp[0].ravel()) == {0, 1}
+    assert set(pp[1].ravel()) == {2, 3}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -107,3 +107,8 @@ def test_bad_inputs():
 
     with pytest.raises(ValueError):
         _ = shape_(3)
+
+
+def test_map():
+    assert xy_(1, 2).map(lambda x: x + 1) == xy_(2, 3)
+    assert xy_(1, 2).map(lambda x: [x]) == xy_([1], [2])


### PR DESCRIPTION
- Adding type hints to all the code in `roi.py` and `_overlap.py`
- Better data model for reporting reprojection info (`_overlap.py`)
- Moved roi and overlap tests out of the giant `test_geom.py`
- Adding `XY[T].map(op)` 

## Context

This code is used by data loading in datacube to figure out what part of the source image one needs to load and at what resolution in order to load requested region, part of the output image affected by the source image is also reported. Other things are also computed like: can we just paste source image onto destination or whether transofrm change or scale change is needed.

With this change done we can start using `odc-geo` in `odc-stac` with some confidence that underlying structures won't be changing much.