### PR TITLE
Improve hashing performance of CRS (#14)

### DIFF
--- a/odc/geo/crs.py
+++ b/odc/geo/crs.py
@@ -191,7 +191,7 @@ class CRS:
         return self._str
 
     def __hash__(self) -> int:
-        return hash(self.to_wkt())
+        return hash(self._str)
 
     def __repr__(self) -> str:
         return f"CRS('{self._str}')"


### PR DESCRIPTION
We already cache `_str` property which uniquely identifies CRS object as
this is used as a key in the cache of pyproj CRSs. So using this instead
of `.to_wkt()` is much faster but should still generate unique-enough
hashes.

```
crs = odc.geo.crs.CRS("epsg:3577")
%timeit crs.to_wkt()
%timeit hash(crs)
--------------------
44.5 µs ± 202 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
379 ns ± 1.86 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

closes #14 