### PR TITLE
Overlap fixes

### DIFF
--- a/odc/geo/converters.py
+++ b/odc/geo/converters.py
@@ -1,0 +1,20 @@
+"""
+Interop with other geometry libraries.
+"""
+
+from typing import List
+
+from .geom import Geometry
+
+
+def from_geopandas(series) -> List[Geometry]:
+    """
+    Convert Geopandas data into list of :py:class:`~odc.geo.geom.Geometry`.
+    """
+    crs = getattr(series, "crs", None)
+    gg = getattr(series, "geometry", None)
+
+    if crs is None or gg is None:
+        return []
+
+    return [Geometry(g, crs) for g in gg]

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -323,12 +323,12 @@ class GeoBox:
         xs = numpy.arange(nx) * rx + (tx + rx / 2)
         ys = numpy.arange(ny) * ry + (ty + ry / 2)
 
-        units = self._crs.units if self._crs is not None else ("1", "1")
+        crs_units = self._crs.units if self._crs is not None else ("1", "1")
 
         return OrderedDict(
             (dim, Coordinate(labels, units, res))
             for dim, labels, units, res in zip(
-                self.dimensions, (ys, xs), units, (ry, rx)
+                self.dimensions, (ys, xs), crs_units, (ry, rx)
             )
         )
 

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -541,7 +541,8 @@ class Geometry:
             yield Geometry(g, self.crs)
 
     def __iter__(self) -> Iterator["Geometry"]:
-        for geom in self.geom.geoms:
+        sub_geoms = getattr(self.geom, "geoms", [])
+        for geom in sub_geoms:
             yield Geometry(geom, self.crs)
 
     def __nonzero__(self) -> bool:

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -426,7 +426,7 @@ def roi_from_points(
     shape = shape_(shape)
 
     def to_roi(*args):
-        return tuple(slice(v[0], v[1]) for v in args)
+        return tuple(slice(int(v[0]), int(v[1])) for v in args)
 
     assert len(shape) == 2
     assert xy.ndim == 2 and xy.shape[1] == 2

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -365,9 +365,9 @@ def shape_(x: SomeShape) -> Shape2d:
     if isinstance(x, Shape2d):
         return x
     if isinstance(x, XY):
-        nx, ny = x.xy
+        nx, ny = x.map(int).xy
         return Shape2d(x=nx, y=ny)
     if isinstance(x, Sequence):
-        ny, nx = x
+        ny, nx = map(int, x)
         return Shape2d(x=nx, y=ny)
     raise ValueError(f"Input type not understood: {type(x)}")

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -30,6 +30,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-timeout
+  - geopandas
 
   # for docs
   - sphinx

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,20 @@
+import geopandas
+import geopandas.datasets
+
+from odc.geo.converters import from_geopandas
+
+
+def test_from_geopandas():
+    df = geopandas.read_file(geopandas.datasets.get_path("naturalearth_lowres"))
+    gg = from_geopandas(df)
+    assert isinstance(gg, list)
+    assert len(gg) == len(df)
+    assert gg[0].crs == "epsg:4326"
+
+    (au,) = from_geopandas(df[df.iso_a3 == "AUS"].to_crs(epsg=3577))
+    assert au.crs.epsg == 3577
+
+    (au,) = from_geopandas(df[df.iso_a3 == "AUS"].to_crs(epsg=3857).geometry)
+    assert au.crs.epsg == 3857
+
+    assert from_geopandas(df.continent) == []


### PR DESCRIPTION
As I start using overlap functionality on real-world datasets in `odc-stac` lib I'm finding that images that span slightly more than the whole globe cause issues. Adding a clamp on coordinates computed from pixel_coord+transform for geoboxes defined in geographic CRSs seems to resolve this issue.

Other things included are:

1. fix in iter(geometry) when geometry is simple and no multi
2. ensuring that plain ints are used when constructing slices/shapes (sometimes numpy.int can get in there instead)
3. conversion method for turning geopandas into list of geometry objects, useful for tests and work in the notebook