### PR TITLE
Some more usage driven improvements

### DIFF
--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -314,7 +314,7 @@ def _wrap_op(method):
 
 def xr_reproject(
     src: xarray.DataArray,
-    dst_geobox: GeoBox,
+    how: Union[SomeCRS, GeoBox],
     *,
     resampling: Union[str, int] = "nearest",
     dst_nodata: Optional[float] = None,
@@ -329,6 +329,16 @@ def xr_reproject(
         raise RuntimeError(
             "Please install `rasterio` to use this method"
         )  # pragma: nocover
+
+    assert isinstance(src.odc, ODCExtension)  # for mypy sake
+
+    if src.odc.geobox is None:
+        raise ValueError("Can not reproject non-georestered array.")
+
+    if isinstance(how, GeoBox):
+        dst_geobox = how
+    else:
+        dst_geobox = src.odc.output_geobox(how)
 
     dst_shape = (*src.shape[:-2], *dst_geobox.shape)
     dst = numpy.empty(dst_shape, dtype=src.dtype)

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -20,6 +20,7 @@ from .crs import CRS, CRSError, SomeCRS, norm_crs_or_error
 from .geobox import Coordinate, GeoBox
 from .geom import Geometry
 from .math import affine_from_axis
+from .overlap import compute_output_geobox
 from .types import Resolution, resxy_
 
 if have.rasterio:
@@ -381,6 +382,18 @@ class ODCExtension:
     @property
     def geobox(self) -> Optional[GeoBox]:
         return self._state.geobox
+
+    def output_geobox(self, crs: SomeCRS, **kw) -> GeoBox:
+        """
+        Compute geobox of this data in other projection.
+
+        ..see-also:: :py:meth:`odc.geo.overlap.compute_output_geobox`
+        """
+        gbox = self.geobox
+        if gbox is None:
+            raise ValueError("Not geo registered")
+
+        return compute_output_geobox(gbox, crs, **kw)
 
 
 @xarray.register_dataarray_accessor("odc")

--- a/odc/geo/crs.py
+++ b/odc/geo/crs.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2015-2020 ODC Contributors
 # SPDX-License-Identifier: Apache-2.0
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union, overload
 
 import cachetools
 import numpy
@@ -287,6 +287,14 @@ class CRSMismatchError(ValueError):
     Raised when geometry operation is attempted on geometries in different
     coordinate references.
     """
+
+
+# fmt: off
+@overload
+def norm_crs(crs: SomeCRS) -> CRS: ...
+@overload
+def norm_crs(crs: None) -> None: ...
+# fmt: on
 
 
 def norm_crs(crs: MaybeCRS) -> Optional[CRS]:

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -238,7 +238,7 @@ class GeoBox:
 
     def is_empty(self) -> bool:
         """Check if geobox is "empty"."""
-        return self._shape.shape == (0, 0)
+        return 0 in self._shape
 
     def __bool__(self) -> bool:
         return not self.is_empty()
@@ -575,13 +575,16 @@ class GeoBox:
         from .ui import pick_grid_step  # pylint: disable=import-outside-toplevel
 
         nx, ny = self._shape.xy
-        if step == 0:
-            step = pick_grid_step(max(nx, ny))
-        xx = [*range(0, nx, step), nx]
-        yy = [*range(0, ny, step), ny]
-        vertical = [list(itertools.product([x], yy)) for x in xx[1:-1]]
-        horizontal = [list(itertools.product(xx, [y])) for y in yy[1:-1]]
-        lines = multiline(vertical + horizontal, self._crs)
+        if nx > 0 and ny > 0:
+            if step == 0:
+                step = pick_grid_step(max(nx, ny))
+            xx = [*range(0, nx, step), nx]
+            yy = [*range(0, ny, step), ny]
+            vertical = [list(itertools.product([x], yy)) for x in xx[1:-1]]
+            horizontal = [list(itertools.product(xx, [y])) for y in yy[1:-1]]
+            lines = multiline(vertical + horizontal, self._crs)
+        else:
+            lines = multiline([], self._crs)
 
         if mode == "pixel":
             return lines

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -492,6 +492,26 @@ class GeoBox:
         """
         return self * Affine.translation(tx, ty)
 
+    @property
+    def left(self) -> "GeoBox":
+        """Same size geobox to the left of this one."""
+        return self.translate_pix(-self.shape.x, 0)
+
+    @property
+    def right(self) -> "GeoBox":
+        """Same size geobox to the right of this one."""
+        return self.translate_pix(self.shape.x, 0)
+
+    @property
+    def top(self) -> "GeoBox":
+        """Same size geobox to the left of this one."""
+        return self.translate_pix(0, -self.shape.y)
+
+    @property
+    def bottom(self) -> "GeoBox":
+        """Same size geobox to the left of this one."""
+        return self.translate_pix(0, self.shape.y)
+
     def rotate(self, deg: float) -> "GeoBox":
         """
         Rotate GeoBox around the center.

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -504,12 +504,12 @@ class GeoBox:
 
     @property
     def top(self) -> "GeoBox":
-        """Same size geobox to the left of this one."""
+        """Same size geobox directly above this one."""
         return self.translate_pix(0, -self.shape.y)
 
     @property
     def bottom(self) -> "GeoBox":
-        """Same size geobox to the left of this one."""
+        """Same size geobox directly below this one."""
         return self.translate_pix(0, self.shape.y)
 
     def rotate(self, deg: float) -> "GeoBox":

--- a/odc/geo/ui.py
+++ b/odc/geo/ui.py
@@ -21,6 +21,9 @@ def norm_units(unit: str) -> str:
 
 
 def pick_grid_step(N: int, at_least: int = 4, no_more: int = 11) -> int:
+    if N <= 0:
+        return 1
+
     factors = [1, 5, 10, 2, 4, 3, 6, 7, 8, 9, 1.5, 2.5]
     n = 10 ** (math.floor(math.log10(N)) - 1)
     if n < 1:
@@ -73,7 +76,11 @@ def svg_base_map(
     # in pixels
     min_span = min(40, sz)
 
-    if span_x > span_y:
+    if min(span_x, span_y) < 1e-4:
+        span_x = span_y = 1e-4
+        w, h = sz, sz
+        s = w / span_x
+    elif span_x > span_y:
         w, h = sz, max(int(sz * span_y / span_x), min_span)
         s = w / span_x
     else:
@@ -131,7 +138,11 @@ def make_svg(
     # in pixels
     min_span = min(40, sz)
 
-    if span_x > span_y:
+    if min(span_x, span_y) < 1e-4:
+        span_x = span_y = 1e-4
+        w, h = sz, sz
+        s = w / span_x
+    elif span_x > span_y:
         w, h = sz, max(int(sz * span_y / span_x), min_span)
         s = w / span_x
     else:

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -166,6 +166,9 @@ def test_gbox_tiles():
     assert tt.shape == (2, 3)
     assert tt[1, 2] == gbox[10:11, 18:22]
 
+    # check .roi
+    assert tt.base[tt.roi[1, 2]] == tt[1, 2]
+
     for idx in [tt.shape, (-1, 0), (0, -1), (-33, 1)]:
         with pytest.raises(IndexError):
             tt[idx]

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -337,3 +337,18 @@ def test_html_repr():
 
     # empty should still work
     assert isinstance((gbox[:0, :0])._repr_html_(), str)
+
+
+def test_lrtb():
+    gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))
+
+    assert gbox.right.left == gbox
+    assert gbox.left.right == gbox
+    assert gbox.top.bottom == gbox
+    assert gbox.bottom.top == gbox
+
+    assert gbox.left == GeoBox.from_bbox([-20, 0, 0, 10], gbox.crs, shape=gbox.shape)
+    assert gbox.right == GeoBox.from_bbox([20, 0, 40, 10], gbox.crs, shape=gbox.shape)
+
+    assert gbox.bottom == GeoBox.from_bbox([0, -10, 20, 0], gbox.crs, shape=gbox.shape)
+    assert gbox.top == GeoBox.from_bbox([0, 10, 20, 20], gbox.crs, shape=gbox.shape)

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -209,6 +209,7 @@ def test_geobox():
     assert bool(gbox) is True
 
     assert (gbox[:3, :4] & gbox[3:, 4:]).is_empty()
+    assert (gbox[:3, :4] & gbox[:3, 4:]).is_empty()
     assert (gbox[:3, :4] & gbox[30:, 40:]).is_empty()
 
     assert gbox[:3, :7].center_pixel == gbox[1, 3]
@@ -310,15 +311,29 @@ def test_svg():
     assert len(gbox.svg()) > 0
     assert gbox.svg(10) != gbox.svg(1)
 
+    assert gbox.grid_lines(mode="pixel").crs == "epsg:3857"
+
     assert isinstance(gbox._repr_svg_(), str)
+
+    # empty should still work
+    assert isinstance((gbox[:3] & gbox[3:])._repr_svg_(), str)
 
 
 def test_html_repr():
     # smoke test only
     gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))
     assert isinstance(gbox._repr_html_(), str)
+    # empties should still work
+    assert isinstance(gbox[:0]._repr_html_(), str)
+    assert isinstance(gbox[:0, :0]._repr_html_(), str)
 
     # no crs case
     gbox = GeoBox(wh_(200, 100), Affine.translation(-10, 20), None)
     assert gbox.crs is None
     assert isinstance(gbox._repr_html_(), str)
+
+    # empty should still work
+    assert isinstance((gbox[:3] & gbox[3:])._repr_html_(), str)
+
+    # empty should still work
+    assert isinstance((gbox[:0, :0])._repr_html_(), str)

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -104,6 +104,7 @@ def test_odc_extension(xx_epsg4326: xr.DataArray, geobox_epsg4326: GeoBox):
     assert xx.spatial_ref.attrs["spatial_ref"] == gbox.crs.wkt
     assert xx.spatial_ref.attrs["grid_mapping_name"] == "latitude_longitude"
     assert xx.odc.uncached.transform == xx.odc.transform
+    assert xx.odc.output_geobox("epsg:3857").crs == "epsg:3857"
 
     # this drops encoding/attributes, but crs/geobox should remain the same
     _xx = xx * 10.0
@@ -122,6 +123,10 @@ def test_odc_extension(xx_epsg4326: xr.DataArray, geobox_epsg4326: GeoBox):
     assert _xx.XX.odc.crs is None
     assert _xx.XX.odc.transform is None
     assert _xx.XX.odc.geobox is None
+
+    # when geobox is none output_geobox should fail
+    with pytest.raises(ValueError):
+        _ = _xx.XX.odc.output_geobox("epsg:4326")
 
 
 def test_odc_extension_ds(xx_epsg4326: xr.DataArray, geobox_epsg4326: GeoBox):


### PR DESCRIPTION
- Refactor in `GeoboxTiles` to allow access to "roi" of a tile not just geobox, needed for data loading logic in odc-stac
  - `odc.roi.Tiles` now contains logic for that, independent of geobox
- Add convenience methods `GeoBox.{left,right,top,bottom}` for moving geobox
- Add `compute_output_geobox()` and expose it as `xx.odc.output_geobox()` as well
  - Construct appropriat geobox for projecting to some other reference (figures out resolution and bounds and makes GeoBox)
- Use `compute_output_geobox` in `xx.odc.reproject(..)` when input is CRS and not fully specified geobox
- Fixed errors in display of empty/single line geoboxes
- more precise type info in `crs.py`