### PR TITLE
Track CRS info in BoundingBox and changes to GeoBox constructors

### DIFF
--- a/docs/geobox.rst
+++ b/docs/geobox.rst
@@ -5,22 +5,28 @@ GeoBox
 .. autosummary::
    :toctree: _api/
 
+   GeoBox.from_geopolygon
+   GeoBox.from_bbox
    GeoBox.affine
-   GeoBox.alignment
    GeoBox.boundary
    GeoBox.buffered
    GeoBox.coordinates
-   GeoBox.coords
    GeoBox.crs
    GeoBox.dimensions
    GeoBox.dims
-   GeoBox.extent
    GeoBox.flipx
    GeoBox.flipy
-   GeoBox.from_geopolygon
+   GeoBox.extent
+   GeoBox.footprint
+   GeoBox.boundingbox
    GeoBox.geographic_extent
+   GeoBox.overlap_roi
    GeoBox.height
    GeoBox.is_empty
+   GeoBox.left
+   GeoBox.right
+   GeoBox.top
+   GeoBox.bottom
    GeoBox.pad
    GeoBox.pad_wh
    GeoBox.resolution

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -114,6 +114,7 @@ class GeoBox:
         :return:
            :py:class:`~odc.geo.geobox.GeoBox` that covers supplied bounding box.
         """
+        # pylint: disable=too-many-locals
 
         _snap: Optional[XY[float]] = None
 

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -342,6 +342,11 @@ class GeoBox:
         self._extent = _extent
         return _extent
 
+    @property
+    def boundingbox(self) -> BoundingBox:
+        """GeoBox bounding box in the native CRS."""
+        return BoundingBox.from_transform(self._shape, self._affine, crs=self._crs)
+
     def _reproject_resolution(self, npoints: int = 100):
         bbox = self.extent.boundingbox
         span = max(bbox.span_x, bbox.span_y)

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -30,6 +30,7 @@ from .types import (
     XY,
     Index2d,
     MaybeInt,
+    NormalizedROI,
     Resolution,
     Shape2d,
     SomeIndex2d,
@@ -245,6 +246,22 @@ class GeoBox:
 
     def __hash__(self):
         return hash((*self._shape, self._crs, self._affine))
+
+    def overlap_roi(self, other: "GeoBox", tol: float = 1e-8) -> NormalizedROI:
+        """
+        Compute overlap as ROI.
+
+        Figure out slice into this geobox that shares pixels with the ``other`` geobox with
+        consistent pixel grid.
+
+        :raises:
+            :py:class:`ValueError` when two geoboxes are not pixel-aligned.
+        """
+        nx, ny = self._shape.xy
+        x0, y0, x1, y1 = map(int, bounding_box_in_pixel_domain(other, self, tol))
+        x0, y0 = max(0, x0), max(0, y0)
+        x1, y1 = min(x1, nx), min(y1, ny)
+        return numpy.s_[y0:y1, x0:x1]
 
     @property
     def transform(self) -> Affine:

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -157,6 +157,10 @@ class BoundingBox(Sequence[float]):
         yy = [y for _, y in pts]
         return BoundingBox(min(xx), min(yy), max(xx), max(yy), self._crs)
 
+    @property
+    def polygon(self) -> "Geometry":
+        return box(*self.bbox, self.crs)
+
     @staticmethod
     def from_xy(
         x: Tuple[float, float], y: Tuple[float, float], crs: MaybeCRS = None
@@ -166,6 +170,7 @@ class BoundingBox(Sequence[float]):
 
         :param x: (left, right)
         :param y: (bottom, top)
+        :param crs: CRS
         """
         x1, x2 = sorted(x)
         y1, y2 = sorted(y)
@@ -180,8 +185,24 @@ class BoundingBox(Sequence[float]):
 
         :param p1: (x, y)
         :param p2: (x, y)
+        :param crs: CRS
         """
         return BoundingBox.from_xy((p1[0], p2[0]), (p1[1], p2[1]), crs)
+
+    @staticmethod
+    def from_transform(
+        shape: SomeShape, transform: Affine, crs: MaybeCRS = None
+    ) -> "BoundingBox":
+        """
+        Construct :py:class:`~odc.geo.geom.BoundingBox` from image shape and transform.
+
+        :param shape: image dimensions
+        :param transform: Affine mapping from pixel to world
+        :param crs: CRS
+        """
+        p1 = transform * (0, 0)
+        p2 = transform * shape_(shape).xy
+        return BoundingBox.from_points(p1, p2, crs=crs)
 
 
 def wrap_shapely(method):

--- a/odc/geo/gridspec.py
+++ b/odc/geo/gridspec.py
@@ -152,13 +152,15 @@ class GridSpec:
         :param bounds: Query bounding box
         :return: Bounding box in tile index space
         """
+        assert self.crs == bounds.crs
+
         x1, y1, x2, y2 = bounds
         ix1, iy1 = self.pt2idx(x1, y1).xy
         ix2, iy2 = self.pt2idx(x2, y2).xy
 
         ix1, ix2 = sorted([ix1, ix2])
         iy1, iy2 = sorted([iy1, iy2])
-        return BoundingBox(ix1, iy1, ix2, iy2)
+        return BoundingBox(ix1, iy1, ix2, iy2, self.crs)
 
     def tiles(
         self, bounds: BoundingBox, geobox_cache: Optional[dict] = None
@@ -191,7 +193,7 @@ class GridSpec:
                 geobox_cache[tile_index] = gbox
             return gbox
 
-        ix1, iy1, ix2, iy2 = self.idx_bounds(bounds)
+        ix1, iy1, ix2, iy2 = map(int, self.idx_bounds(bounds))
 
         for iy in range(iy1, iy2 + 1):
             for ix in range(ix1, ix2 + 1):

--- a/odc/geo/math.py
+++ b/odc/geo/math.py
@@ -123,25 +123,26 @@ def is_almost_int(x: float, tol: float) -> bool:
     return x < tol
 
 
-def _snap_edge_pos(x0: float, x1: float, res: float) -> Tuple[float, int]:
+def _snap_edge_pos(x0: float, x1: float, res: float, tol: float) -> Tuple[float, int]:
     assert res > 0
     assert x1 >= x0
-    _x0, _x1 = floor(x0 / res), ceil(x1 / res)
+    _x0 = floor(maybe_int(x0 / res, tol))
+    _x1 = ceil(maybe_int(x1 / res, tol))
     nx = max(1, _x1 - _x0)
     return _x0 * res, nx
 
 
-def _snap_edge(x0: float, x1: float, res: float) -> Tuple[float, int]:
+def _snap_edge(x0: float, x1: float, res: float, tol: float) -> Tuple[float, int]:
     assert x1 >= x0
     if res > 0:
-        return _snap_edge_pos(x0, x1, res)
-    _tx, nx = _snap_edge_pos(x0, x1, -res)
+        return _snap_edge_pos(x0, x1, res, tol)
+    _tx, nx = _snap_edge_pos(x0, x1, -res, tol)
     tx = _tx + nx * (-res)
     return tx, nx
 
 
 def snap_grid(
-    x0: float, x1: float, res: float, off_pix: Optional[float] = 0
+    x0: float, x1: float, res: float, off_pix: Optional[float] = 0, tol: float = 1e-6
 ) -> Tuple[float, int]:
     """
     Compute grid snapping for single axis.
@@ -160,13 +161,13 @@ def snap_grid(
     assert (off_pix is None) or (0 <= off_pix < 1)
     if off_pix is None:
         if res > 0:
-            nx = ceil((x1 - x0) / res)
+            nx = ceil(maybe_int((x1 - x0) / res, tol))
             return x0, max(1, nx)
-        nx = ceil((x1 - x0) / (-res))
+        nx = ceil(maybe_int((x1 - x0) / (-res), tol))
         return x1, max(nx, 1)
 
     off = off_pix * abs(res)
-    _tx, nx = _snap_edge(x0 - off, x1 - off, res)
+    _tx, nx = _snap_edge(x0 - off, x1 - off, res, tol)
     return _tx + off, nx
 
 

--- a/odc/geo/overlap.py
+++ b/odc/geo/overlap.py
@@ -670,17 +670,7 @@ def compute_output_geobox(
     src_crs = gbox.crs
     assert src_crs is not None
 
-    # do about 100 point per side and pad by 0.9 pixel to figure out bounding box
-    # in the new projection
-    src_span = max(gbox.extent.boundingbox.span_x, gbox.extent.boundingbox.span_y)
-    src_pix_sz = max(abs(gbox.resolution.x), abs(gbox.resolution.y))
-
-    bbox = (
-        gbox.extent.buffer(src_pix_sz * 0.9)
-        .to_crs(dst_crs, resolution=src_span / 100)
-        .boundingbox
-    )
-
+    bbox = gbox.footprint(dst_crs, buffer=0.9, npoints=100).boundingbox
     same_units = src_crs.units == dst_crs.units
 
     if resolution == "same":

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -10,50 +10,27 @@ will have an ROI that can be constructed with :py:func:`numpy.s_` like this: ``s
 """
 import math
 from collections import abc
-from typing import Optional, Protocol, Tuple, Union, overload
+from typing import Optional, Tuple, Union, overload
 
 import numpy as np
 
 from .math import align_down, align_up
-from .types import Shape2d, SomeIndex2d, SomeShape, T, iyx_, shape_
+from .types import (
+    NdROI,
+    NormalizedROI,
+    NormalizedSlice,
+    Shape2d,
+    SomeIndex2d,
+    SomeShape,
+    SomeSlice,
+    T,
+    iyx_,
+    shape_,
+)
 
 # This is numeric code, short names make sense in this context, so disabling
 # "invalid name" checks for the whole file
 # pylint: disable=invalid-name
-
-# fmt: off
-class NormalizedSlice(Protocol):
-    """
-    Type for ``slice`` with start/stop set to integer values.
-    """
-    @property
-    def start(self) -> int: ...
-    @property
-    def stop(self) -> int: ...
-    @property
-    def step(self) -> Optional[int]: ...
-# fmt: on
-
-SomeSlice = Union[slice, int, NormalizedSlice]
-"""
-Slice index into ndarray or a single int.
-
-Single index is equivalent to ``slice(idx, idx+1)``.
-"""
-
-NdROI = Union[SomeSlice, Tuple[SomeSlice, ...]]
-"""
-Any dimensional slice into ndarray.
-
-This could be a single ``int`` or slice ``slice`` or a tuple of any number
-of those things.
-"""
-
-ROI = Tuple[SomeSlice, SomeSlice]
-"""2d slice into an image plane."""
-
-NormalizedROI = Tuple[NormalizedSlice, NormalizedSlice]
-"""Normalized 2d slice into an image plane."""
 
 
 class WindowFromSlice:

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -6,6 +6,7 @@ from typing import (
     Iterator,
     Literal,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
     TypeVar,
@@ -371,3 +372,38 @@ def shape_(x: SomeShape) -> Shape2d:
         ny, nx = map(int, x)
         return Shape2d(x=nx, y=ny)
     raise ValueError(f"Input type not understood: {type(x)}")
+
+
+# fmt: off
+class NormalizedSlice(Protocol):
+    """
+    Type for ``slice`` with start/stop set to integer values.
+    """
+    @property
+    def start(self) -> int: ...
+    @property
+    def stop(self) -> int: ...
+    @property
+    def step(self) -> Optional[int]: ...
+# fmt: on
+
+SomeSlice = Union[slice, int, NormalizedSlice]
+"""
+Slice index into ndarray or a single int.
+
+Single index is equivalent to ``slice(idx, idx+1)``.
+"""
+
+NdROI = Union[SomeSlice, Tuple[SomeSlice, ...]]
+"""
+Any dimensional slice into ndarray.
+
+This could be a single ``int`` or slice ``slice`` or a tuple of any number
+of those things.
+"""
+
+ROI = Tuple[SomeSlice, SomeSlice]
+"""2d slice into an image plane."""
+
+NormalizedROI = Tuple[NormalizedSlice, NormalizedSlice]
+"""Normalized 2d slice into an image plane."""

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -7,8 +7,9 @@ import numpy as np
 import pytest
 from affine import Affine
 
-from odc.geo import CRS, geom, ixy_, resyx_, wh_
+from odc.geo import CRS, geom, ixy_, resyx_, wh_, xy_
 from odc.geo.geobox import (
+    AnchorEnum,
     GeoBox,
     bounding_box_in_pixel_domain,
     gbox_boundary,
@@ -307,6 +308,18 @@ def test_from_bbox():
         GeoBox.from_bbox(geom.BoundingBox(*bbox, "epsg:3857"), shape=shape).crs
         == "epsg:3857"
     )
+
+    assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.FLOATING
+    ) == GeoBox.from_bbox(bbox, shape=shape, tight=True)
+
+    assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.EDGE
+    ) == GeoBox.from_bbox(bbox, shape=shape, anchor=xy_(0, 0))
+
+    assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.CENTER
+    ) == GeoBox.from_bbox(bbox, shape=shape, anchor=xy_(0.5, 0.5))
 
     # one of resolution= or shape= must be supplied
     with pytest.raises(ValueError):

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -290,6 +290,12 @@ def test_from_bbox():
     assert GeoBox.from_bbox(bbox, shape=shape, tight=False) != gbox
     assert GeoBox.from_bbox(bbox, resolution=gbox.resolution, tight=False) != gbox
 
+    assert GeoBox.from_bbox(geom.BoundingBox(*bbox), shape=shape).crs == "epsg:4326"
+    assert (
+        GeoBox.from_bbox(geom.BoundingBox(*bbox, "epsg:3857"), shape=shape).crs
+        == "epsg:3857"
+    )
+
     # one of resolution= or shape= must be supplied
     with pytest.raises(ValueError):
         _ = GeoBox.from_bbox(bbox)

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -166,6 +166,7 @@ def test_geobox():
     w, h = 512, 256
     gbox = GeoBox(wh_(w, h), A, epsg3577)
     assert gbox.boundingbox.crs is epsg3577
+    assert gbox.footprint("epsg:4326") == gbox.geographic_extent
 
     assert gbox.shape == (h, w)
     assert gbox.transform == A

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -165,6 +165,7 @@ def test_geobox():
 
     w, h = 512, 256
     gbox = GeoBox(wh_(w, h), A, epsg3577)
+    assert gbox.boundingbox.crs is epsg3577
 
     assert gbox.shape == (h, w)
     assert gbox.transform == A

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -230,6 +230,16 @@ def test_geobox():
         )
 
 
+def test_gbox_overlap_roi():
+    gbox = GeoBox(wh_(100, 30), Affine.translation(0, 0), epsg4326)
+    assert gbox.overlap_roi(gbox[3:7, 13:29]) == np.s_[3:7, 13:29]
+    assert gbox[10:20, 5:10].overlap_roi(gbox) == np.s_[0:10, 0:5]
+
+    a = gbox[10:20, 20:40]
+    b = gbox[11:30, 10:25]
+    assert a.overlap_roi(b) == np.s_[1:10, 0:5]
+
+
 def test_gbox_boundary():
     geobox = GeoBox(wh_(6, 2), Affine.translation(0, 0), epsg4326)
 

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -15,6 +15,7 @@ from odc.geo import CRS, BoundingBox, CRSMismatchError, geom, wh_
 from odc.geo.crs import norm_crs, norm_crs_or_error
 from odc.geo.geobox import GeoBox, _align_pix, _round_to_res
 from odc.geo.geom import (
+    bbox_intersection,
     bbox_union,
     chop_along_antimeridian,
     clip_lon180,
@@ -58,7 +59,7 @@ def test_props():
     assert isinstance(box1.wkt, str)
 
     triangle = geom.polygon([(10, 20), (20, 20), (20, 10), (10, 20)], crs=crs)
-    assert triangle.boundingbox == geom.BoundingBox(10, 10, 20, 20)
+    assert triangle.boundingbox == geom.BoundingBox(10, 10, 20, 20, crs)
     assert triangle.envelope.contains(triangle)
 
     assert box1.length == 80.0
@@ -377,15 +378,22 @@ def test_boundingbox():
     assert bb.width == bb.span_x
     assert bb.height == bb.span_y
     assert bb.shape == (bb.height, bb.width)
+    assert bb.crs is None
+    assert bb.bbox == (0, 3, 2, 4)
+    assert "crs=" not in str(bb)
+    assert "crs=" not in repr(bb)
 
-    bb = BoundingBox(0, 3, 2.1, 4)
+    bb = BoundingBox(0, 3, 2.1, 4, "epsg:4326")
     assert bb.width == 2
     assert bb.height == 1
     assert bb.span_x == 2.1
     assert bb.width != bb.span_x
     assert bb.height == bb.span_y
+    assert bb.crs.epsg == 4326
+    assert "crs=" in str(bb)
+    assert "crs=" in repr(bb)
 
-    assert BoundingBox.from_xy(bb.range_x, bb.range_y) == bb
+    assert BoundingBox.from_xy(bb.range_x, bb.range_y, bb.crs) == bb
 
     assert BoundingBox.from_xy((1, 2), (10, 20)) == (1, 10, 2, 20)
     assert BoundingBox.from_xy((2, 1), (20, 10)) == (1, 10, 2, 20)
@@ -404,18 +412,35 @@ def test_densify():
     assert densify(s_x10, 4) == [(0, 0), (4, 0), (8, 0), (10, 0)]
 
 
-def test_bbox_union():
-    b1 = BoundingBox(0, 1, 10, 20)
-    b2 = BoundingBox(5, 6, 11, 22)
+@pytest.mark.parametrize("crs", [None, "epsg:4326", epsg3857])
+def test_bbox_union(crs):
+    b1 = BoundingBox(0, 1, 10, 20, crs)
+    b2 = BoundingBox(5, 6, 11, 22, crs)
 
     assert bbox_union([b1]) == b1
     assert bbox_union([b2]) == b2
 
     bb = bbox_union(iter([b1, b2]))
-    assert bb == BoundingBox(0, 1, 11, 22)
+    assert bb == BoundingBox(0, 1, 11, 22, crs)
 
     bb = bbox_union(iter([b2, b1] * 10))
-    assert bb == BoundingBox(0, 1, 11, 22)
+    assert bb == BoundingBox(0, 1, 11, 22, crs)
+
+
+@pytest.mark.parametrize(
+    "crss",
+    [
+        (None, "epsg:4326", epsg3857),
+        ("epsg:4326", "epsg:3857"),
+        (*["epsg:4326"] * 4, "epsg:3857"),
+    ],
+)
+def test_bbox_crs_mismatch(crss):
+    with pytest.raises(ValueError):
+        _ = bbox_union(BoundingBox(0, 0, 1, 1, crs) for crs in crss)
+
+    with pytest.raises(ValueError):
+        _ = bbox_intersection(BoundingBox(0, 0, 1, 1, crs) for crs in crss)
 
 
 def test_unary_union():

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -13,7 +13,7 @@ from shapely.errors import ShapelyDeprecationWarning
 
 from odc.geo import CRS, BoundingBox, CRSMismatchError, geom, wh_
 from odc.geo.crs import norm_crs, norm_crs_or_error
-from odc.geo.geobox import GeoBox, _align_pix, _round_to_res
+from odc.geo.geobox import GeoBox, _round_to_res
 from odc.geo.geom import (
     bbox_intersection,
     bbox_union,
@@ -825,25 +825,6 @@ def test_geom_clone():
 
     assert b == geom.Geometry(b)
     assert b.geom is not geom.Geometry(b).geom
-
-
-@pytest.mark.parametrize(
-    "left, right, res, off, expect",
-    [
-        (20, 30, 10, 0, (20, 1)),
-        (20, 30.5, 10, 0, (20, 1)),
-        (20, 31.5, 10, 0, (20, 2)),
-        (20, 30, 10, 3, (13, 2)),
-        (20, 30, 10, -3, (17, 2)),
-        (20, 30, -10, 0, (30, 1)),
-        (19.5, 30, -10, 0, (30, 1)),
-        (18.5, 30, -10, 0, (30, 2)),
-        (20, 30, -10, 3, (33, 2)),
-        (20, 30, -10, -3, (37, 2)),
-    ],
-)
-def test_align_pix(left, right, res, off, expect):
-    assert _align_pix(left, right, res, off) == expect
 
 
 def test_lonlat_bounds():

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -403,6 +403,18 @@ def test_boundingbox():
     assert BoundingBox(1, 3, 10, 20).buffered(1, 3) == (0, 0, 11, 23)
     assert BoundingBox(1, 3, 10, 20).buffered(1) == (0, 2, 11, 21)
 
+    assert BoundingBox.from_transform(
+        wh_(10, 12), Affine.translation(1, 3), "epsg:3857"
+    ) == (1, 3, 11, 15)
+    assert (
+        BoundingBox.from_transform(
+            wh_(10, 12), Affine.translation(1, 3), "epsg:3857"
+        ).crs
+        == "epsg:3857"
+    )
+
+    assert bb.polygon.boundingbox == bb
+
 
 def test_densify():
     s_x10 = [(0, 0), (10, 0)]

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -16,6 +16,7 @@ from odc.geo.math import (
     maybe_int,
     maybe_zero,
     snap_affine,
+    snap_grid,
     snap_scale,
     split_translation,
 )
@@ -216,3 +217,20 @@ def test_snap_affine():
         ttol=0.2,
         stol=1e-3,
     ) == mkA(scale=(1 / 2, 1 / 3), translation=(10, 20))
+
+
+@pytest.mark.parametrize(
+    "left, right, res, off, expect",
+    [
+        (20, 30, 10, 0, (20, 1)),
+        (20, 30.5, 10, 0, (20, 2)),
+        (20, 31.5, 10, 0, (20, 2)),
+        (20, 30, 10, 3, (13, 2)),
+        (20, 30, -10, 0, (30, 1)),
+        (19.5, 30, -10, 0, (30, 2)),
+        (18.5, 30, -10, 0, (30, 2)),
+        (20, 30, -10, 3, (33, 2)),
+    ],
+)
+def test_snap_grid(left, right, res, off, expect):
+    assert snap_grid(left, right, res, off / abs(res)) == expect

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -234,3 +234,7 @@ def test_snap_affine():
 )
 def test_snap_grid(left, right, res, off, expect):
     assert snap_grid(left, right, res, off / abs(res)) == expect
+
+
+def test_snap_grid_tol():
+    assert snap_grid(0.95, 10.12, 1, 0, 0.1) == (1.0, 10)


### PR DESCRIPTION
1. BoundingBox was an odd one out without CRS info attached, now it has that
   - This enables other conveniences, two way conversion polygon<->bbox
  
2. Changes to GeoBox.from_bbox
   - Can get CRS info directly from bounding box now
   - Replace confusing "align" that is pretty hard to explain with "anchor"

Essentially if you take `0,0` in the real world, bring it to pixel space and locate pixel that contains it, then you want location within that pixel to be a certain point in `[0, 1), [0, 1)`, so `0,0` is edge aligned, same as `align=(0,0)` used to be, and to get center aligned pixel you pick `(0.5, 0.5)`. Also you can just not align at all, in which case resulted geobox will start at left,top and might go a little bit over right, bottom.

Also adds some more convenience methods to bounding box and geobox.

Closes #25 

