### PR TITLE
Release 0.1.2

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -98,6 +98,12 @@ odc.geo.geom
    Geometry.to_crs
    Geometry.geojson
    BoundingBox
+   BoundingBox.from_xy
+   BoundingBox.from_points
+   BoundingBox.from_transform
+   BoundingBox.transform
+   BoundingBox.buffered
+
 
    box
    line

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -193,3 +193,39 @@ odc.geo.gridspec
    GridSpec.tiles_from_geopolygon
 
    GridSpec.geojson
+
+odc.geo.xr
+**********
+
+.. currentmodule:: odc.geo.xr
+.. autosummary::
+   :toctree: _api/
+
+   ODCExtension
+   ODCExtension.geobox
+   ODCExtension.output_geobox
+   ODCExtensionDa
+   ODCExtensionDa.assign_crs
+   ODCExtensionDa.write_cog
+   ODCExtensionDa.to_cog
+   ODCExtensionDa.reproject
+   ODCExtensionDs
+   assign_crs
+   rasterize
+   spatial_dims
+   wrap_xr
+   xr_coords
+   xr_reproject
+   xr_zeros
+
+odc.geo.overlap
+***************
+
+.. currentmodule:: odc.geo.overlap
+.. autosummary::
+   :toctree: _api/
+
+   ReprojectInfo
+   affine_from_pts
+   compute_output_geobox
+   compute_reproject_roi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,11 @@ import odc.geo.geom
 
 odc.geo.crs.geom = odc.geo.geom
 
+# autotypes work around 2
+import odc.geo.overlap
+
+odc.geo.overlap.CRS = odc.geo.crs.CRS
+
 # -- Project information -----------------------------------------------------
 
 project = "odc-geo"

--- a/odc/geo/_version.py
+++ b/odc/geo/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -105,18 +105,17 @@ def _get_crs_from_attrs(obj: XarrayObject, sdims: Tuple[str, str]) -> Optional[C
 def spatial_dims(
     xx: Union[xarray.DataArray, xarray.Dataset], relaxed: bool = False
 ) -> Optional[Tuple[str, str]]:
-    """Find spatial dimensions of `xx`.
+    """
+    Find spatial dimensions of ``xx``.
 
     Checks for presence of dimensions named:
-      y, x | latitude, longitude | lat, lon
+    ``y, x | latitude, longitude | lat, lon``
 
-    Returns
-    =======
-    None -- if no dimensions with expected names are found
-    ('y', 'x') | ('latitude', 'longitude') | ('lat', 'lon')
-
-    If *relaxed* is True and none of the above dimension names are found,
+    If ``relaxed=True`` and none of the above dimension names are found,
     assume that last two dimensions are spatial dimensions.
+
+    :returns: ``None`` if no dimensions with expected names are found
+    :returns: ``('y', 'x') | ('latitude', 'longitude') | ('lat', 'lon')``
     """
     guesses = [("y", "x"), ("latitude", "longitude"), ("lat", "lon")]
 
@@ -200,15 +199,12 @@ def xr_coords(
     Dictionary of Coordinates in xarray format.
 
     :param crs_coord_name:
-       Use custom name for CRS coordinate, default is "spatial_ref".
-       Set to ``None`` to not generate CRS coordinate at all.
+       Use custom name for CRS coordinate, default is "spatial_ref". Set to ``None`` to not generate
+       CRS coordinate at all.
 
-    Returns
-    =======
-
-    Dictionary name:str -> xr.DataArray
-
-    where names are either ``y,x`` for projected or ``latitude, longitude`` for geographic.
+    :returns:
+      Dictionary ``name:str -> xr.DataArray``. Where names are either ``y,x`` for projected or
+      ``latitude, longitude`` for geographic.
 
     """
     attrs = {}
@@ -523,7 +519,7 @@ def xr_zeros(
     Construct geo-registered xarray from a :py:class:`~odc.geo.geobox.GeoBox`.
 
     :param gbox: Desired footprint and resolution
-    :return: :class:py:`xarray.DataArray` filled with zeros
+    :return: :py:class:`xarray.DataArray` filled with zeros
     """
     return wrap_xr(
         numpy.zeros(geobox.shape, dtype=dtype),

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -167,6 +167,8 @@ class GeoBox:
         geopolygon: Geometry,
         resolution: SomeResolution,
         crs: MaybeCRS = None,
+        align: Optional[XY[float]] = None,
+        *,
         anchor: GeoboxAnchor = AnchorEnum.EDGE,
         tol: float = 0.01,
     ) -> "GeoBox":
@@ -175,18 +177,26 @@ class GeoBox:
 
         :param resolution:
            Either a single number or a :py:class:`~odc.geo.types.Resolution` object.
+
         :param crs:
            CRS to use, if different from the geopolygon
+
+        :param align:
+            Deprecated: please switch to ``anchor=``
 
         :param anchor:
             By default snaps grid such that pixel edges fall on X/Y axis.
 
-         :param tol:
+        :param tol:
             Fraction of a pixel that can be ignored, defaults to 1/100. Bounding box of the output
             geobox is allowed to be smaller than supplied bounding box by that amount.
 
         """
         resolution = res_(resolution)
+        if align is not None:
+            # support old-style "align", which is basically anchor but in CRS units
+            ax, ay = align.xy
+            anchor = xy_(ax / abs(resolution.x), ay / abs(resolution.y))
         if crs is None:
             crs = geopolygon.crs
         else:

--- a/odc/geo/overlap.py
+++ b/odc/geo/overlap.py
@@ -651,10 +651,11 @@ def compute_output_geobox(
        Desired CRS of the output
 
     :param resolution:
+
        * "same" use exactly the same resolution as src
        * "fit" use center pixel to determine scale change between the two
-       * "auto" is to use the same resolution on the output if CRS units are the same
-          between the source and destination and otherwise use "fit"
+       * | "auto" is to use the same resolution on the output if CRS units are the same
+         |  between the source and destination and otherwise use "fit"
 
     :param tight:
       By default output pixel grid is adjusted to align pixel edges to X/Y axis, suppling

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -287,6 +287,18 @@ def test_non_st():
         assert gbox.coordinates
 
 
+def test_from_polygon():
+    box = geom.box(1, 13, 17, 37, "epsg:4326")
+    gbox = GeoBox.from_geopolygon(box, 0.1)
+    assert gbox.crs == box.crs
+    assert gbox.extent.boundingbox == box.boundingbox
+    assert gbox.resolution.y < 0
+
+    # check that align= still works by name and by order
+    assert gbox == GeoBox.from_geopolygon(gbox.extent, gbox.resolution, None, xy_(0, 0))
+    assert gbox == GeoBox.from_geopolygon(gbox.extent, gbox.resolution, align=xy_(0, 0))
+
+
 def test_from_bbox():
     bbox = (1, 13, 17, 37)
     shape = (23, 47)


### PR DESCRIPTION
- exposing more methods in docs
- restore `align=` argument for backwards compatibility
- fix doc comments
- bump version