### PR TITLE
Support arbitrary geoboxes in xarray + fixes

### DIFF
--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -12,7 +12,7 @@ from typing import Dict, Iterable, List, Literal, Optional, Tuple, Union
 import numpy
 from affine import Affine
 
-from .crs import CRS, MaybeCRS, SomeCRS, norm_crs
+from .crs import CRS, CRSMismatchError, MaybeCRS, SomeCRS, norm_crs
 from .geom import (
     BoundingBox,
     Geometry,
@@ -1066,6 +1066,9 @@ class GeoboxTiles:
             _in = clamp(math.floor(v1), 0, N)
             _out = clamp(math.ceil(v2), 0, N)
             return range(_in, _out)
+
+        if bbox.crs != self._gbox.crs:
+            raise CRSMismatchError()
 
         sy, sx = self._tiles.tile_shape((0, 0)).yx
         A = Affine.scale(1.0 / sx, 1.0 / sy) * (~self._gbox.transform)

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -1072,7 +1072,7 @@ class GeoboxTiles:
         # A maps from X,Y in meters to chunk index
         bbox = bbox.transform(A)
 
-        NY, NX = self._tiles.base.yx
+        NY, NX = self._tiles.shape.yx
         xx = clamped_range(bbox.left, bbox.right, NX)
         yy = clamped_range(bbox.bottom, bbox.top, NY)
         return (yy, xx)

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -612,6 +612,13 @@ class GeoBox:
         return False
 
     @property
+    def axis_aligned(self):
+        """
+        Check if Geobox is axis-aligned (not rotated).
+        """
+        return self._confirm_axis_aligned()
+
+    @property
     def center_pixel(self) -> "GeoBox":
         """
         GeoBox of a center pixel.

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -191,3 +191,9 @@ def test_gbox_tiles():
     assert tt.chunk_shape((0, 1)) == (h, 2)
     assert tt.chunk_shape((1, 1)) == (1, 2)
     assert tt.chunk_shape((1, 0)) == (1, w)
+
+    # check that overhang get's clamped properly
+    assert tt.range_from_bbox(gbox.pad(2).boundingbox) == (
+        range(0, tt.shape[0]),
+        range(0, tt.shape[1]),
+    )

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 from affine import Affine
 
+from odc.geo import CRSMismatchError
 from odc.geo import geobox as gbx
 from odc.geo import geom as geometry
 from odc.geo import wh_
@@ -197,3 +198,6 @@ def test_gbox_tiles():
         range(0, tt.shape[0]),
         range(0, tt.shape[1]),
     )
+
+    with pytest.raises(CRSMismatchError):
+        _ = tt.range_from_bbox(gbox.geographic_extent.boundingbox)

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -178,6 +178,7 @@ def test_geobox():
     assert gbox.alignment.yx == (4, 0)  # 4 because -2983006 % 10 is 4
     assert isinstance(str(gbox), str)
     assert "EPSG:3577" in repr(gbox)
+    assert gbox.axis_aligned is True
 
     assert GeoBox((1, 1), mkA(0), epsg4326).geographic_extent.crs == epsg4326
     assert GeoBox((1, 1), mkA(0), None).dimensions == ("y", "x")
@@ -282,6 +283,7 @@ def test_non_st():
     gbox = GeoBox((1, 1), A, "epsg:3857")
 
     assert gbox._confirm_axis_aligned() is False
+    assert gbox.axis_aligned is False
 
     with pytest.raises(ValueError):
         assert gbox.coordinates


### PR DESCRIPTION
### Main feature
Add support for rotated geoboxes #28.

When geobox is not axis aligned do not compute X/Y axis, but instead
- X: `0.5, 1.5 ... W-0.5`
- Y: `0.5, 1.5 ... H-0.5`
- Store 6 floats of the original transform in `pix.{x,y}.encoding['_transform']`
- Then during `pix.odc.geobox` computation detect that and adjust geobox accordingly

This works fine, and handles cropping as well, but there is one annoying detail: `pix.plot.imshow()` will display image up side down, doing `pix.plot.imshow(yincrease=False)` overcomes this problem. I think that this is fine as it's going to pretty uncommon to work with rotated geoboxes.

Here is sample image displayed in qgis that has non-axis-aligned geobox, generated and saved from `odc-geo`.

![image](https://user-images.githubusercontent.com/1428024/167586671-f202efe7-d0a3-4313-94d1-21f41117c307.png)

While actual pixels are arranged like this:

![image](https://user-images.githubusercontent.com/1428024/167588534-b6d5f5e7-c81b-441e-97f8-e88040460424.png)



### Some fixes
- Fixes error in tiles computation when requested geometry reaches outside of valid tiles.
- Now that boundingbox carries CRS info we can verify it's the correct one



