### PR TITLE
Fix geobox resolution display for rotated geoboxes

### DIFF
--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -24,7 +24,7 @@ from .geom import (
     point,
     polygon_from_transform,
 )
-from .math import clamp, is_affine_st, is_almost_int, snap_grid
+from .math import clamp, is_affine_st, is_almost_int, resolution_from_affine, snap_grid
 from .roi import Tiles as RoiTiles
 from .roi import align_up, polygon_path, roi_normalise, roi_shape
 from .types import (
@@ -39,7 +39,6 @@ from .types import (
     SomeShape,
     iyx_,
     res_,
-    resxy_,
     shape_,
     xy_,
 )
@@ -328,8 +327,7 @@ class GeoBox:
     @property
     def resolution(self) -> Resolution:
         """Resolution, pixel size in CRS units."""
-        rx, _, _, _, ry, *_ = self._affine
-        return resxy_(rx, ry)
+        return resolution_from_affine(self._affine)
 
     @property
     def alignment(self) -> XY[float]:

--- a/odc/geo/math.py
+++ b/odc/geo/math.py
@@ -13,7 +13,7 @@ from typing import List, Literal, Optional, Sequence, Tuple, TypeVar, Union
 import numpy as np
 from affine import Affine
 
-from .types import XY, SomeResolution, res_, xy_
+from .types import XY, Resolution, SomeResolution, res_, resxy_, xy_
 
 AffineX = TypeVar("AffineX", np.ndarray, Affine)
 
@@ -420,6 +420,20 @@ def affine_from_pts(X: Sequence[XY[float]], Y: Sequence[XY[float]]) -> Affine:
     a, d, b, e, c, f = mm.ravel()
 
     return Affine(a, b, c, d, e, f)
+
+
+def resolution_from_affine(A: Affine) -> Resolution:
+    """
+    Compute resolution from Affine matrix.
+
+    Deals with rotated case when needed.
+    """
+    if is_affine_st(A):
+        rx, _, _, _, ry, *_ = A
+        return resxy_(rx, ry)
+    _, _, A_ = decompose_rws(A)
+    rx, _, _, _, ry, *_ = A_
+    return resxy_(rx, ry)
 
 
 class Bin1D:

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -59,6 +59,8 @@ def test_geobox_simple():
     )
     expect_resolution = pytest.approx((-0.00025, 0.00025))
     assert t.resolution.yx == expect_resolution
+    assert t.rotate(33).resolution.yx == expect_resolution
+    assert t.rotate(-11.37).resolution.yx == expect_resolution
 
     assert t.coordinates["latitude"].values.shape == (4000,)
     assert t.coordinates["longitude"].values.shape == (4000,)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -15,6 +15,7 @@ from odc.geo.math import (
     is_almost_int,
     maybe_int,
     maybe_zero,
+    resolution_from_affine,
     snap_affine,
     snap_grid,
     snap_scale,
@@ -238,3 +239,11 @@ def test_snap_grid(left, right, res, off, expect):
 
 def test_snap_grid_tol():
     assert snap_grid(0.95, 10.12, 1, 0, 0.1) == (1.0, 10)
+
+
+def test_res_affine():
+    assert resolution_from_affine(mkA(scale=(2, 3))).xy == (2, 3)
+    assert resolution_from_affine(mkA(rot=10, scale=(2, 3))).xy == pytest.approx((2, 3))
+    assert resolution_from_affine(mkA(rot=-45, scale=(10, -10))).xy == pytest.approx(
+        (10, -10)
+    )

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -12,19 +12,16 @@ from affine import Affine
 from odc.geo import CRS, geom, resyx_, wh_, xy_
 from odc.geo.geobox import GeoBox, scaled_down_geobox
 from odc.geo.gridspec import GridSpec
-from odc.geo.math import is_affine_st
+from odc.geo.math import affine_from_pts, decompose_rws, is_affine_st, stack_xy
 from odc.geo.overlap import (
     LinearPointTransform,
     ReprojectInfo,
     _can_paste,
-    affine_from_pts,
     compute_axis_overlap,
     compute_output_geobox,
     compute_reproject_roi,
-    decompose_rws,
     get_scale_at_point,
     native_pix_transform,
-    stack_xy,
 )
 from odc.geo.roi import (
     roi_is_empty,


### PR DESCRIPTION
- move affine math code around (consolidate all of it in math.py)
- add method to extract resolution from affine matrix even when rotation/shear components are present
