### PR TITLE
Adding display on a map

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,8 +73,8 @@ pygments_style = "friendly"
 autosummary_generate = True
 
 extlinks = {
-    "issue": ("https://github.com/opendatacube/odc-geo/issues/%s", "issue "),
-    "pull": ("https://github.com/opendatacube/odc-geo/pulls/%s", "PR "),
+    "issue": ("https://github.com/opendatacube/odc-geo/issues/%s", "issue %s"),
+    "pull": ("https://github.com/opendatacube/odc-geo/pulls/%s", "PR %s"),
 }
 
 intersphinx_mapping = {

--- a/odc/geo/_compress.py
+++ b/odc/geo/_compress.py
@@ -1,0 +1,97 @@
+import base64
+import warnings
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import rasterio
+import xarray as xr
+
+from ._interop import is_dask_collection
+from ._rgba import replace_transparent_pixels
+
+# Driver, Compress Option Name
+_fmt_info = {
+    "png": ("PNG", "zlevel", "image/png"),
+    "jpeg": ("JPEG", "quality", "image/jpeg"),
+    "webp": ("WEBP", "quality", "image/webp"),
+}
+
+
+def _compress_image(im: np.ndarray, driver="PNG", **opts) -> bytes:
+
+    if im.ndim > 2:
+        im = np.squeeze(im)
+
+    if im.ndim == 3:
+        h, w, nc = im.shape
+        bands = np.transpose(im, axes=(2, 0, 1))  # Y,X,B -> B,Y,X
+    elif im.ndim == 2:
+        (h, w), nc = im.shape, 1
+        bands = im.reshape(nc, h, w)
+    else:
+        raise ValueError(f"Expect 2 or 3 dimensional array got: {im.ndim}")
+
+    rio_opts = dict(width=w, height=h, count=nc, driver=driver, dtype=im.dtype, **opts)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", rasterio.errors.NotGeoreferencedWarning)
+
+        with rasterio.MemoryFile() as mem:
+            with mem.open(**rio_opts) as dst:
+                dst.write(bands)
+            return mem.read()
+
+
+def compress(
+    xx,
+    /,
+    *args,
+    as_data_url=False,
+    transparent: Optional[Tuple[int, int, int]] = None,
+    **kw,
+) -> Union[str, bytes]:
+    """
+    Save image to RAM in jpeg/png/webp format.
+
+    .. code:: python
+
+       png_bytes = compress(xx)  # default is PNG
+       png_bytes = compress(xx, "png", 9) # compression settings
+
+       # - Make data url with JPEG quality of 85
+       # - Use black for transparent pixels (JPEG doesn't support transparency)
+       # - Result is an ASCII string
+       url = compress(xx, "jpeg", 85, as_data_url=True, transparent=(0,0,0))
+
+    :param xx: DataArray to compress
+    :param transparent:
+      Pixel value to use for transparent pixels, useful for jpeg output.
+
+    """
+    fmt = "png"
+    opts = {}
+    if len(args) >= 1:
+        fmt, *_ = args
+
+    driver, opt_name, mime_type = _fmt_info.get(fmt.lower(), (None, "", ""))
+    if driver is None:
+        raise ValueError(f"Format '{fmt}', is not suported, try jpeg/png/webp")
+
+    if len(args) >= 2:
+        _, comp, *_ = args
+        opts[opt_name] = comp
+
+    if isinstance(xx, xr.DataArray):
+        xx = xx.data
+
+    if is_dask_collection(xx):
+        xx = xx.compute()
+
+    if transparent is not None:
+        xx = replace_transparent_pixels(xx, transparent)
+
+    _bytes = _compress_image(xx, driver, **opts, **kw)
+    if not as_data_url:
+        return _bytes
+
+    return f"data:{mime_type};base64," + base64.encodebytes(_bytes).decode("ascii")

--- a/odc/geo/_interop.py
+++ b/odc/geo/_interop.py
@@ -4,6 +4,9 @@ Tools for interop with other libraries.
 Check if libraries available without importing them which can be slow.
 """
 import importlib.util
+from typing import Any, Callable
+
+# pylint: disable=import-outside-toplevel
 
 
 class _LibChecker:
@@ -29,3 +32,27 @@ class _LibChecker:
 
 
 have = _LibChecker()
+__all__ = ("have",)
+
+
+def __dir__():
+    return [*__all__, "is_dask_collection"]
+
+
+def __getattr__(name):
+    if name == "is_dask_collection":
+        if have.dask:
+            import dask
+
+            return dask.is_dask_collection
+
+        # pylint: disable=redefined-outer-name
+        def is_dask_collection(_: Any) -> bool:
+            return False
+
+        return is_dask_collection
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+is_dask_collection: Callable[[Any], bool]

--- a/odc/geo/_interop.py
+++ b/odc/geo/_interop.py
@@ -26,6 +26,14 @@ class _LibChecker:
     def dask(self) -> bool:
         return self._check("dask")
 
+    @property
+    def folium(self) -> bool:
+        return self._check("folium")
+
+    @property
+    def ipyleaflet(self) -> bool:
+        return self._check("ipyleaflet")
+
     @staticmethod
     def _check(lib_name):
         return importlib.util.find_spec(lib_name) is not None

--- a/odc/geo/_map.py
+++ b/odc/geo/_map.py
@@ -1,0 +1,125 @@
+from typing import Any, Optional, Tuple
+
+import xarray as xr
+
+from ._interop import have
+from ._rgba import colorize, is_rgb
+
+
+# pylint: disable=import-outside-toplevel, redefined-builtin, too-many-locals
+def _add_to_folium(url, bounds, map, name=None, **kw):
+    assert have.folium
+
+    from folium.raster_layers import ImageOverlay
+
+    img_overlay = ImageOverlay(url, bounds, **kw)
+    img_overlay.add_to(map, name=name)
+    return img_overlay
+
+
+def _add_to_ipyleaflet(url, bounds, map, name=None, **kw):
+    assert have.ipyleaflet
+
+    from ipyleaflet import ImageOverlay, Map
+
+    assert isinstance(map, Map)
+
+    if name is not None:
+        kw.update(name=name)
+
+    img_overlay = ImageOverlay(url=url, bounds=bounds, **kw)
+    map.add_layer(img_overlay)
+
+    return img_overlay
+
+
+def _get_add_to_method(map):
+    if map is None:
+        return None
+
+    map_module = getattr(map, "__module__", "")
+
+    if "folium" in map_module:
+        return _add_to_folium
+
+    if "ipyleaflet" in map_module:
+        return _add_to_ipyleaflet
+
+    raise ValueError(f"Not sure how to add image to: '{type(map)}'")
+
+
+def add_to(
+    xx: Any,
+    map: Any,
+    *,
+    name: Optional[str] = None,
+    fmt: str = "png",
+    max_size: int = 4096,
+    # jpeg options:
+    transparent_pixel: Optional[Tuple[int, int, int]] = None,
+    # RGB conversion parameters
+    cmap: Optional[Any] = None,
+    clip: bool = False,
+    # passed to ImageOverlay constructor
+    **kw,
+) -> Any:
+    """
+    Add image to a map.
+
+    If map is not supplied, image data url and bounds are returned instead.
+
+    :param xx: array to display
+    :param map:
+       Map object, :py:mod:`folium` and :py:mod:`ipyleaflet` are understood, can be ``None``.
+
+    :param name: Image layer name
+    :param fmt: compress image format, defaults to "png", can be "webp", "jpeg" as well.
+    :param max_size:
+       If longest dimension is bigger than this, shrink it down before compression, defaults to 4096
+    :param transparent_pixel: Replace transparent pixels with this value, needed for "jpeg".
+    :param cmap: If supplied array is not RGB use this colormap to turn it into one
+    :param clip: When converting to RGB clip input values to fit ``cmap``.
+    :raises ValueError: when map object is not understood
+    :return: ImageLayer that was added to a map
+    :return: ``(url, bounds)`` when ``map is None``.
+    """
+    from .xr import ODCExtensionDa
+
+    assert isinstance(xx, xr.DataArray)
+    assert isinstance(xx.odc, ODCExtensionDa)
+
+    _add_to = _get_add_to_method(map)  # raises on error
+
+    need_reproject = False
+
+    gbox = xx.odc.geobox
+    assert gbox is not None
+    assert gbox.crs is not None
+
+    if gbox.crs.epsg != 3857:
+        need_reproject = True
+        gbox = gbox.to_crs("epsg:3857", tight=True)
+
+    if max(*gbox.shape) > max_size:
+        need_reproject = True
+        gbox = gbox.zoom_to(max_size)
+
+    if need_reproject:
+        xx = xx.odc.reproject(gbox)
+
+    if not is_rgb(xx):
+        xx = colorize(xx, cmap=cmap, clip=clip)
+
+    compress_opts = [fmt]
+    for opt in ["zlevel", "quality"]:
+        if (v := kw.pop(opt, None)) is not None:
+            compress_opts.append(v)
+
+    url = xx.odc.compress(
+        *compress_opts, as_data_url=True, transparent=transparent_pixel
+    )
+    bounds = gbox.map_bounds()
+    if _add_to is None:
+        return url, bounds
+
+    return _add_to(url, gbox.map_bounds(), map, name=name, **kw)

--- a/odc/geo/_rgba.py
+++ b/odc/geo/_rgba.py
@@ -196,3 +196,20 @@ def colorize(
         data = _np_colorize(x.data, cmap, clip)
 
     return xr.DataArray(data=data, dims=dims, coords=coords, attrs=attrs)
+
+
+def replace_transparent_pixels(
+    rgba: np.ndarray, color: Tuple[int, int, int] = (255, 0, 255)
+) -> np.ndarray:
+    """
+    Convert RGBA to RGB.
+
+    Replaces transparent pixels with a given color.
+    """
+    assert rgba.ndim == 3
+    assert rgba.shape[-1] == 4
+
+    m = rgba[..., -1] == 0
+    rgb = rgba[..., :3].copy()
+    rgb[m] = color
+    return rgb

--- a/odc/geo/_rgba.py
+++ b/odc/geo/_rgba.py
@@ -1,0 +1,198 @@
+""" Helpers for dealing with RGB(A) images.
+"""
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+import xarray as xr
+
+from ._interop import is_dask_collection
+
+
+def is_rgb(x: xr.DataArray):
+    """
+    Check if array is RGB(A).
+    """
+    if x.dtype != "uint8":
+        return False
+    if x.ndim < 3:
+        return False
+    if x.shape[-1] not in (3, 4):
+        return False
+    return True
+
+
+def _guess_rgb_names(bands: List[str]) -> Tuple[str, str, str]:
+    def _candidate(color: str) -> str:
+        candidates = [name for name in bands if color in name]
+        n = len(candidates)
+        if n == 1:
+            return candidates[0]
+
+        if n == 0:
+            raise ValueError(f'Found no candidate for color "{color}"')
+        raise ValueError(f'Found too many candidates for color "{color}"')
+
+    r, g, b = [_candidate(c) for c in ("red", "green", "blue")]
+    return (r, g, b)
+
+
+def _auto_guess_clamp(ds: xr.Dataset) -> Tuple[float, float]:
+    # TODO: deal with nodata > 0 case
+    return (float(0), max(x.data.max() for x in ds.data_vars.values()))
+
+
+def _to_u8(x: np.ndarray, x_min: float, x_max: float) -> np.ndarray:
+    x = np.clip(x, x_min, x_max)
+
+    if x.dtype.kind == "f":
+        x = (x - x_min) * (255.0 / (x_max - x_min))
+    else:
+        x = (x - x_min).astype("uint32") * 255 // (x_max - x_min)
+    return x.astype("uint8")
+
+
+def _np_to_rgba(
+    r: np.ndarray,
+    g: np.ndarray,
+    b: np.ndarray,
+    nodata: Optional[float],
+    clamp: Tuple[float, float],
+) -> np.ndarray:
+    rgba = np.zeros((*r.shape, 4), dtype="uint8")
+
+    if r.dtype.kind == "f":
+        valid = ~np.isnan(r)
+        if nodata is not None:
+            valid = valid * (r != nodata)
+    elif nodata is not None:
+        valid = r != nodata
+    else:
+        valid = np.ones(r.shape, dtype=np.bool8)
+
+    rgba[..., 3] = valid.astype("uint8") * (0xFF)
+    for idx, band in enumerate([r, g, b]):
+        rgba[..., idx] = _to_u8(band, *clamp)
+
+    return rgba
+
+
+def to_rgba(
+    ds: xr.Dataset,
+    clamp: Optional[Union[float, Tuple[float, float]]] = None,
+    bands: Optional[Tuple[str, str, str]] = None,
+) -> xr.DataArray:
+    """
+    Convert dataset to RGBA image.
+
+    Given :py:class:`xarray.Dataset` with bands ``red,green,blue`` construct :py:class:`xarray.Datarray`
+    containing ``uint8`` rgba image.
+
+    :param ds: :py:class:`xarray.Dataset`
+    :param clamp:
+      ``(min_intensity, max_intensity) | max_intensity == (0, max_intensity)``. Can also
+       supply ``None`` for non-dask inputs, in which case clamp is set to ``(0, max(r,g,b))``.
+
+    :param bands: Which bands to use, order should be red,green,blue
+    """
+    # pylint: disable=too-many-locals
+    if bands is None:
+        bands = _guess_rgb_names(list(ds.data_vars))
+
+    is_dask = is_dask_collection(ds)
+
+    if clamp is None:
+        if is_dask:
+            raise ValueError("Must specify clamp for Dask inputs")
+        clamp = _auto_guess_clamp(ds[list(bands)])
+    elif not isinstance(clamp, tuple):
+        clamp = (float(0), float(clamp))
+
+    _b = ds[bands[0]]
+    nodata = getattr(_b, "nodata", None)
+    dims = (*_b.dims, "band")
+
+    r, g, b = (ds[name].data for name in bands)
+    if is_dask:
+        # pylint: disable=import-outside-toplevel
+        from dask import array as da
+        from dask.base import tokenize
+
+        assert _b.chunks is not None
+        data = da.map_blocks(
+            _np_to_rgba,
+            r,
+            g,
+            b,
+            nodata,
+            clamp,
+            name=f"ro_rgba-{tokenize(r, g, b)}",
+            dtype=np.uint8,
+            chunks=(*_b.chunks, (4,)),
+            new_axis=[r.ndim],
+        )
+    else:
+        data = _np_to_rgba(r, g, b, nodata, clamp)
+
+    coords = dict(_b.coords.items())
+    coords.update(band=xr.DataArray(data=["r", "g", "b", "a"], dims=("band",)))
+
+    rgba = xr.DataArray(data, coords=coords, dims=dims)
+    return rgba
+
+
+def _np_colorize(x, cmap, clip):
+    if x.dtype == "bool":
+        x = x.astype("uint8")
+    if clip:
+        x = np.clip(x, 0, cmap.shape[0] - 1)
+    return cmap[x]
+
+
+def colorize(
+    x: xr.DataArray,
+    cmap: np.ndarray,
+    attrs=None,
+    *,
+    clip: bool = False,
+) -> xr.DataArray:
+    """
+    Map categorical values from ``x`` to RGBA according to ``cmap`` lookup table.
+
+    :param x: Input xarray data array (can be Dask)
+    :param cmap: Lookup table ``cmap[x] -> RGB(A)``
+    :param attrs: xarray attributes table, if not supplied input attributes are copied across
+    :param clip: If ``True`` clip values from ``x`` to be in the safe range for ``cmap``.
+    """
+    assert cmap.ndim == 2
+    assert cmap.shape[1] in (3, 4)
+
+    if attrs is None:
+        attrs = x.attrs
+
+    nc = cmap.shape[1]
+    dims = (*x.dims, "band")
+    coords = dict(x.coords.items())
+    coords["band"] = xr.DataArray(data=["r", "g", "b", "a"][:nc], dims=("band",))
+
+    if is_dask_collection(x.data):
+        # pylint: disable=import-outside-toplevel
+        from dask import array as da
+        from dask import delayed
+        from dask.base import tokenize
+
+        _cmap = delayed(cmap)
+        assert x.chunks is not None
+        data = da.map_blocks(
+            _np_colorize,
+            x.data,
+            _cmap,
+            clip,
+            name=f"colorize-{tokenize(x, cmap)}",
+            dtype=cmap.dtype,
+            chunks=(*x.chunks, (nc,)),
+            new_axis=[x.data.ndim],
+        )
+    else:
+        data = _np_colorize(x.data, cmap, clip)
+
+    return xr.DataArray(data=data, dims=dims, coords=coords, attrs=attrs)

--- a/odc/geo/_rgba.py
+++ b/odc/geo/_rgba.py
@@ -1,6 +1,6 @@
 """ Helpers for dealing with RGB(A) images.
 """
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 import xarray as xr
@@ -77,7 +77,7 @@ def _np_to_rgba(
 
 
 def to_rgba(
-    ds: xr.Dataset,
+    ds: Any,
     clamp: Optional[Union[float, Tuple[float, float]]] = None,
     bands: Optional[Tuple[str, str, str]] = None,
 ) -> xr.DataArray:
@@ -95,6 +95,8 @@ def to_rgba(
     :param bands: Which bands to use, order should be red,green,blue
     """
     # pylint: disable=too-many-locals
+    assert isinstance(ds, xr.Dataset)
+
     if bands is None:
         bands = _guess_rgb_names(list(ds.data_vars))
 
@@ -149,8 +151,8 @@ def _np_colorize(x, cmap, clip):
 
 
 def colorize(
-    x: xr.DataArray,
-    cmap: np.ndarray,
+    x: Any,
+    cmap: Any,
     attrs=None,
     *,
     clip: bool = False,
@@ -163,6 +165,7 @@ def colorize(
     :param attrs: xarray attributes table, if not supplied input attributes are copied across
     :param clip: If ``True`` clip values from ``x`` to be in the safe range for ``cmap``.
     """
+    assert isinstance(x, xr.DataArray)
     assert cmap.ndim == 2
     assert cmap.shape[1] in (3, 4)
 

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -27,6 +27,7 @@ from .types import Resolution, resxy_
 # pylint: disable=import-outside-toplevel
 if have.rasterio:
     from ._cog import to_cog, write_cog
+    from ._compress import compress
     from .warp import rio_reproject
 
 XarrayObject = Union[xarray.DataArray, xarray.Dataset]
@@ -450,6 +451,7 @@ class ODCExtensionDa(ODCExtension):
     if have.rasterio:
         write_cog = _wrap_op(write_cog)
         to_cog = _wrap_op(to_cog)
+        compress = _wrap_op(compress)
         reproject = _wrap_op(xr_reproject)
 
 

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -39,6 +39,7 @@ from .types import Resolution, resxy_
 if have.rasterio:
     from ._cog import to_cog, write_cog
     from ._compress import compress
+    from ._map import add_to
     from .warp import rio_reproject
 
 XarrayObject = Union[xarray.DataArray, xarray.Dataset]
@@ -496,6 +497,7 @@ class ODCExtensionDa(ODCExtension):
         to_cog = _wrap_op(to_cog)
         compress = _wrap_op(compress)
         reproject = _wrap_op(xr_reproject)
+        add_to = _wrap_op(add_to)
 
 
 @xarray.register_dataset_accessor("odc")

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -446,6 +446,18 @@ class ODCExtensionDa(ODCExtension):
     def uncached(self) -> "ODCExtensionDa":
         return ODCExtensionDa(self._xx)
 
+    @property
+    def ydim(self) -> int:
+        if (sdims := self.spatial_dims) is not None:
+            return self._xx.dims.index(sdims[0])
+        raise ValueError("Can't locate spatial dimensions")
+
+    @property
+    def xdim(self) -> int:
+        if (sdims := self.spatial_dims) is not None:
+            return self._xx.dims.index(sdims[1])
+        raise ValueError("Can't locate spatial dimensions")
+
     def assign_crs(
         self, crs: SomeCRS, crs_coord_name: str = _DEFAULT_CRS_COORD_NAME
     ) -> xarray.DataArray:

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -16,6 +16,7 @@ import xarray
 from affine import Affine
 
 from ._interop import have
+from ._rgba import colorize, to_rgba
 from .crs import CRS, CRSError, SomeCRS, norm_crs_or_error
 from .geobox import Coordinate, GeoBox
 from .geom import Geometry
@@ -23,8 +24,9 @@ from .math import affine_from_axis
 from .overlap import compute_output_geobox
 from .types import Resolution, resxy_
 
+# pylint: disable=import-outside-toplevel
 if have.rasterio:
-    from ._cog import to_cog, write_cog  # pylint: disable=import-outside-toplevel
+    from ._cog import to_cog, write_cog
     from .warp import rio_reproject
 
 XarrayObject = Union[xarray.DataArray, xarray.Dataset]
@@ -443,6 +445,8 @@ class ODCExtensionDa(ODCExtension):
     ) -> xarray.DataArray:
         return assign_crs(self._xx, crs=crs, crs_coord_name=crs_coord_name)
 
+    colorize = _wrap_op(colorize)
+
     if have.rasterio:
         write_cog = _wrap_op(write_cog)
         to_cog = _wrap_op(to_cog)
@@ -467,6 +471,13 @@ class ODCExtensionDs(ODCExtension):
         self, crs: SomeCRS, crs_coord_name: str = _DEFAULT_CRS_COORD_NAME
     ) -> xarray.Dataset:
         return assign_crs(self._ds, crs=crs, crs_coord_name=crs_coord_name)
+
+    def to_rgba(
+        self,
+        clamp: Optional[Union[float, Tuple[float, float]]] = None,
+        bands: Optional[Tuple[str, str, str]] = None,
+    ) -> xarray.DataArray:
+        return to_rgba(self._ds, clamp=clamp, bands=bands)
 
 
 def _xarray_geobox(xx: XarrayObject) -> Optional[GeoBox]:

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -415,6 +415,17 @@ class GeoBox:
         """GeoBox bounding box in the native CRS."""
         return BoundingBox.from_transform(self._shape, self._affine, crs=self._crs)
 
+    def map_bounds(
+        self, *args, **kw
+    ) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+        """
+        Query bounds in folium/ipyleaflet style.
+
+        Returns SW, and NE corners in lat/lon order.
+        ``((lat_w, lon_s), (lat_e, lon_n))``.
+        """
+        return self.boundingbox.map_bounds(*args, **kw)
+
     def _reproject_resolution(self, npoints: int = 100):
         bbox = self.extent.boundingbox
         span = max(bbox.span_x, bbox.span_y)

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -387,6 +387,40 @@ class GeoBox:
         span = max(bbox.span_x, bbox.span_y)
         return span / npoints
 
+    def to_crs(
+        self,
+        crs: SomeCRS,
+        *,
+        resolution: Literal["auto", "fit", "same"] = "auto",
+        tight: bool = False,
+    ) -> "GeoBox":
+        """
+        Compute GeoBox covering the same region in a different projection.
+
+        :param crs:
+           Desired CRS of the output
+
+        :param resolution:
+
+           * "same" use exactly the same resolution as src
+           * "fit" use center pixel to determine scale change between the two
+           * | "auto" is to use the same resolution on the output if CRS units are the same
+             |  between the source and destination and otherwise use "fit"
+
+        :param tight:
+          By default output pixel grid is adjusted to align pixel edges to X/Y axis, suppling
+          ``tight=True`` produces unaligned geobox on the output.
+
+        :return:
+           Similar resolution, axis aligned geobox that fully encloses this one but in a different
+           projection.
+        """
+        # pylint: disable=import-outside-toplevel
+        # can't be up-top due to circular imports issues
+        from .overlap import compute_output_geobox
+
+        return compute_output_geobox(self, crs, resolution=resolution, tight=tight)
+
     def footprint(
         self, crs: SomeCRS, buffer: float = 0, npoints: int = 100
     ) -> Geometry:

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -286,7 +286,7 @@ class Geometry:
     by dropping the Z points.
     """
 
-    # pylint: disable=protected-access, too-many-public-methods
+    # pylint: disable=protected-access, too-many-public-methods, multiple-statements
 
     def __init__(
         self,
@@ -311,148 +311,83 @@ class Geometry:
     def clone(self) -> "Geometry":
         return Geometry(self)
 
+    # fmt: off
     @wrap_shapely
-    def contains(self, other: "Geometry") -> bool:
-        return self.contains(other)
-
+    def contains(self, other: "Geometry") -> bool: return self.contains(other)
     @wrap_shapely
-    def crosses(self, other: "Geometry") -> bool:
-        return self.crosses(other)
-
+    def crosses(self, other: "Geometry") -> bool: return self.crosses(other)
     @wrap_shapely
-    def disjoint(self, other: "Geometry") -> bool:
-        return self.disjoint(other)
-
+    def disjoint(self, other: "Geometry") -> bool: return self.disjoint(other)
     @wrap_shapely
-    def intersects(self, other: "Geometry") -> bool:
-        return self.intersects(other)
-
+    def intersects(self, other: "Geometry") -> bool: return self.intersects(other)
     @wrap_shapely
-    def touches(self, other: "Geometry") -> bool:
-        return self.touches(other)
-
+    def touches(self, other: "Geometry") -> bool: return self.touches(other)
     @wrap_shapely
-    def within(self, other: "Geometry") -> bool:
-        return self.within(other)
-
+    def within(self, other: "Geometry") -> bool: return self.within(other)
     @wrap_shapely
-    def overlaps(self, other: "Geometry") -> bool:
-        return self.overlaps(other)
-
+    def overlaps(self, other: "Geometry") -> bool: return self.overlaps(other)
     @wrap_shapely
-    def difference(self, other: "Geometry") -> "Geometry":
-        return self.difference(other)
-
+    def difference(self, other: "Geometry") -> "Geometry": return self.difference(other)
     @wrap_shapely
-    def intersection(self, other: "Geometry") -> "Geometry":
-        return self.intersection(other)
-
+    def intersection(self, other: "Geometry") -> "Geometry": return self.intersection(other)
     @wrap_shapely
-    def symmetric_difference(self, other: "Geometry") -> "Geometry":
-        return self.symmetric_difference(other)
-
+    def symmetric_difference(self, other: "Geometry") -> "Geometry": return self.symmetric_difference(other)
     @wrap_shapely
-    def union(self, other: "Geometry") -> "Geometry":
-        return self.union(other)
-
+    def union(self, other: "Geometry") -> "Geometry": return self.union(other)
     @wrap_shapely
-    def __and__(self, other: "Geometry") -> "Geometry":
-        return self.__and__(other)
-
+    def __and__(self, other: "Geometry") -> "Geometry": return self.__and__(other)
     @wrap_shapely
-    def __or__(self, other: "Geometry") -> "Geometry":
-        return self.__or__(other)
-
+    def __or__(self, other: "Geometry") -> "Geometry": return self.__or__(other)
     @wrap_shapely
-    def __xor__(self, other: "Geometry") -> "Geometry":
-        return self.__xor__(other)
-
+    def __xor__(self, other: "Geometry") -> "Geometry": return self.__xor__(other)
     @wrap_shapely
-    def __sub__(self, other: "Geometry") -> "Geometry":
-        return self.__sub__(other)
+    def __sub__(self, other: "Geometry") -> "Geometry": return self.__sub__(other)
 
-    def svg(self, *args, **kw) -> str:
-        return self.geom.svg(*args, *kw)
+    def svg(self, *args, **kw) -> str: return self.geom.svg(*args, *kw)
 
-    def _repr_svg_(self) -> str:
-        return self.geom._repr_svg_()
+    def _repr_svg_(self) -> str: return self.geom._repr_svg_()
 
     @property
-    def type(self) -> str:
-        return self.geom.type
-
+    def type(self) -> str: return self.geom.type
     @property
-    def is_empty(self) -> bool:
-        return self.geom.is_empty
-
+    def is_empty(self) -> bool: return self.geom.is_empty
     @property
-    def is_valid(self) -> bool:
-        return self.geom.is_valid
-
+    def is_valid(self) -> bool: return self.geom.is_valid
     @property
-    def is_ring(self) -> bool:
-        return self.geom.is_ring
-
+    def is_ring(self) -> bool: return self.geom.is_ring
     @property
-    def boundary(self) -> "Geometry":
-        return Geometry(self.geom.boundary, self.crs)
-
+    def boundary(self) -> "Geometry": return Geometry(self.geom.boundary, self.crs)
     @property
-    def exterior(self) -> "Geometry":
-        return Geometry(self.geom.exterior, self.crs)
-
+    def exterior(self) -> "Geometry": return Geometry(self.geom.exterior, self.crs)
     @property
-    def interiors(self) -> List["Geometry"]:
-        return [Geometry(g, self.crs) for g in self.geom.interiors]
-
+    def interiors(self) -> List["Geometry"]: return [Geometry(g, self.crs) for g in self.geom.interiors]
     @property
-    def centroid(self) -> "Geometry":
-        return Geometry(self.geom.centroid, self.crs)
-
+    def centroid(self) -> "Geometry": return Geometry(self.geom.centroid, self.crs)
     @property
-    def coords(self) -> CoordList:
-        return list(self.geom.coords)
-
+    def coords(self) -> CoordList: return list(self.geom.coords)
     @property
-    def points(self) -> CoordList:
-        return self.coords
-
+    def points(self) -> CoordList: return self.coords
     @property
-    def length(self) -> float:
-        return self.geom.length
-
+    def length(self) -> float: return self.geom.length
     @property
-    def area(self) -> float:
-        return self.geom.area
-
+    def area(self) -> float: return self.geom.area
     @property
-    def xy(self) -> Tuple[array.array, array.array]:
-        return self.geom.xy
-
+    def xy(self) -> Tuple[array.array, array.array]: return self.geom.xy
     @property
-    def convex_hull(self) -> "Geometry":
-        return Geometry(self.geom.convex_hull, self.crs)
-
+    def convex_hull(self) -> "Geometry": return Geometry(self.geom.convex_hull, self.crs)
     @property
-    def envelope(self) -> "Geometry":
-        return Geometry(self.geom.envelope, self.crs)
-
+    def envelope(self) -> "Geometry": return Geometry(self.geom.envelope, self.crs)
     @property
     def boundingbox(self) -> BoundingBox:
         minx, miny, maxx, maxy = self.geom.bounds
         return BoundingBox(left=minx, right=maxx, bottom=miny, top=maxy, crs=self.crs)
-
     @property
-    def wkt(self) -> str:
-        return self.geom.wkt
-
+    def wkt(self) -> str: return self.geom.wkt
     @property
-    def __array_interface__(self):
-        return self.geom.__array_interface__
-
+    def __array_interface__(self): return self.geom.__array_interface__
     @property
-    def __geo_interface__(self):
-        return self.geom.__geo_interface__
+    def __geo_interface__(self): return self.geom.__geo_interface__
+    # fmt: on
 
     @property
     def json(self):

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -115,6 +115,11 @@ class BoundingBox(Sequence[float]):
         return self.top - self.bottom
 
     @property
+    def aspect(self) -> float:
+        """Aspect ratio."""
+        return self.span_x / self.span_y
+
+    @property
     def width(self) -> int:
         """``int(span_x)``"""
         return int(self.right - self.left)

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -19,7 +19,7 @@ from .types import SomeShape, shape_
 
 CoordList = List[Tuple[float, float]]
 
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-public-methods
 
 
 class BoundingBox(Sequence[float]):
@@ -305,7 +305,7 @@ class Geometry:
     by dropping the Z points.
     """
 
-    # pylint: disable=protected-access, too-many-public-methods, multiple-statements
+    # pylint: disable=protected-access, multiple-statements
 
     def __init__(
         self,

--- a/odc/geo/testutils.py
+++ b/odc/geo/testutils.py
@@ -13,7 +13,7 @@ from .geobox import GeoBox
 from .gridspec import GridSpec
 from .math import apply_affine
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,
 
 epsg4326 = CRS("EPSG:4326")
 epsg3577 = CRS("EPSG:3577")
@@ -206,3 +206,18 @@ def purge_crs_info(xx: xr.DataArray) -> xr.DataArray:
     # purge attributes from coords and xx
     cc = {name: _purge_attributes(coord) for name, coord in xx.coords.items()}
     return _purge_attributes(xx.assign_coords(cc))
+
+
+def daskify(xx, **kw):
+    # pylint: disable=import-outside-toplevel
+    from dask import array as da
+
+    if isinstance(xx, xr.Dataset):
+        return xr.Dataset({name: daskify(v) for name, v in xx.data_vars.items()})
+
+    return xr.DataArray(
+        data=da.from_array(xx.data, **kw),
+        dims=xx.dims,
+        coords=xx.coords,
+        attrs=xx.attrs,
+    )

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -128,6 +128,11 @@ class XY(Generic[T]):
         """
         return xy_(op(self.x), op(self.y))
 
+    @property
+    def aspect(self) -> float:
+        """Aspect ratio (X/Y)."""
+        return float(self.x) / float(self.y)  # type: ignore
+
 
 class Resolution(XY[float]):
     """

--- a/odc/geo/warp.py
+++ b/odc/geo/warp.py
@@ -177,7 +177,7 @@ def _rio_reproject(
             return arr, False
         wk_dtype = dtype_remap[arr.dtype.name]
         if arr.dtype.name == "bool":
-            T, F = (np.array(v, dtype=wk_dtype) for v in [0, 255])
+            F, T = (np.array(v, dtype=wk_dtype) for v in [0, 255])
             return np.where(arr, T, F), True
         return arr.astype(wk_dtype), False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,5 @@ disable = [
   "invalid-name",
   "fixme",
   "wrong-import-order",
+  "cyclic-import",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+import xarray as xr
+
+from odc.geo.data import ocean_geom
+from odc.geo.geobox import GeoBox
+from odc.geo.xr import rasterize
+
+
+@pytest.fixture()
+def ocean_raster() -> xr.DataArray:
+    gbox = GeoBox.from_bbox(bbox=(-180, -90, 180, 90), shape=(128, 256))
+    return rasterize(ocean_geom(), gbox)
+
+
+@pytest.fixture()
+def ocean_raster_ds(ocean_raster: xr.DataArray) -> xr.Dataset:
+    xx = ocean_raster.astype("int16") * 3_000
+    xx.attrs["nodata"] = -1
+
+    return xr.Dataset(
+        dict(
+            red=xx,
+            green=xx,
+            blue=xx,
+        )
+    )

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -32,6 +32,8 @@ dependencies:
   - pytest-timeout
   - geopandas
   - dask-core
+  - folium
+  - ipyleaflet
 
   # for docs
   - sphinx

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -80,3 +80,19 @@ def test_bbox_crs_mismatch(crss):
 
     with pytest.raises(ValueError):
         _ = bbox_intersection(BoundingBox(0, 0, 1, 1, crs) for crs in crss)
+
+
+def test_map_bounds():
+    bbox = BoundingBox(-180, -90, 180, 90, "epsg:4326")
+    assert bbox.map_bounds() == ((-90, -180), (90, 180))
+
+    bbox = BoundingBox(-180, -90, 180, 90)
+    assert bbox.map_bounds() == ((-90, -180), (90, 180))
+
+    bbox = BoundingBox(-10, -20, 24, 0, "epsg:4326")
+    assert bbox.to_crs("epsg:3857").map_bounds() == ((-20, -10), (0, 24))
+
+
+def test_bbox_to_crs():
+    bbox = BoundingBox(-10, -20, 100, 0, "epsg:4326")
+    assert bbox.to_crs("epsg:3857") == bbox.polygon.to_crs("epsg:3857").boundingbox

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -26,5 +26,7 @@ def test_have():
     assert isinstance(have.rasterio, bool)
     assert isinstance(have.xarray, bool)
     assert isinstance(have.dask, bool)
+    assert isinstance(have.folium, bool)
+    assert isinstance(have.ipyleaflet, bool)
     assert have.rasterio is True
     assert have.xarray is True

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -307,6 +307,7 @@ def test_from_polygon():
     assert gbox.crs == box.crs
     assert gbox.shape.wh == (300, 200)
     assert gbox.resolution.x == -gbox.resolution.y
+    assert gbox.aspect == 300 / 200
 
     gbox = GeoBox.from_geopolygon(box, tight=True, shape=(100, 29))
     assert gbox.crs == box.crs

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -253,6 +253,8 @@ def test_gbox_boundary():
     assert set(bb.T[0]) == {0.0, 3.0, 6.0}
     assert set(bb.T[1]) == {0.0, 1.0, 2.0}
 
+    assert geobox.map_bounds() == geobox.boundingbox.map_bounds()
+
 
 def test_geobox_scale_down():
 

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -302,6 +302,16 @@ def test_from_polygon():
     assert gbox == GeoBox.from_geopolygon(gbox.extent, gbox.resolution, None, xy_(0, 0))
     assert gbox == GeoBox.from_geopolygon(gbox.extent, gbox.resolution, align=xy_(0, 0))
 
+    box = geom.box(-1, 10, 2, 12, "epsg:4326")
+    gbox = GeoBox.from_geopolygon(box, tight=True, shape=300)
+    assert gbox.crs == box.crs
+    assert gbox.shape.wh == (300, 200)
+    assert gbox.resolution.x == -gbox.resolution.y
+
+    gbox = GeoBox.from_geopolygon(box, tight=True, shape=(100, 29))
+    assert gbox.crs == box.crs
+    assert gbox.shape.wh == (29, 100)
+
 
 def test_from_bbox():
     bbox = (1, 13, 17, 37)
@@ -324,6 +334,14 @@ def test_from_bbox():
         GeoBox.from_bbox(geom.BoundingBox(*bbox, "epsg:3857"), shape=shape).crs
         == "epsg:3857"
     )
+
+    gbox = GeoBox.from_bbox((0, 0, 2, 3), tight=True, shape=300, crs="epsg:3857")
+    assert gbox.shape.wh == (200, 300)
+    assert gbox.resolution.x == -gbox.resolution.y
+
+    gbox = GeoBox.from_bbox((-1, 0, 2, 2), tight=True, shape=300, crs="epsg:3857")
+    assert gbox.shape.wh == (300, 200)
+    assert gbox.resolution.x == -gbox.resolution.y
 
     assert GeoBox.from_bbox(
         bbox, shape=shape, anchor=AnchorEnum.FLOATING

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from odc.geo._interop import have
+from odc.geo.xr import ODCExtensionDa
+
+cmap = np.asarray(
+    [
+        [153, 153, 102, 255],
+        [51, 102, 153, 255],
+    ],
+    dtype="uint8",
+)
+
+
+def test_add_to(ocean_raster: xr.DataArray):
+    # Check map safe range first
+    xx = ocean_raster.copy()[20:-20]
+    assert isinstance(xx.odc, ODCExtensionDa)
+
+    url, bounds = xx.odc.add_to(None, cmap=cmap, max_size=32, zlevel=1)
+    assert isinstance(url, str)
+    assert url.startswith("data:")
+    assert "image/png" in url
+    assert isinstance(bounds, tuple)
+    assert isinstance(bounds[0], tuple)
+    assert isinstance(bounds[0], tuple)
+
+    url, bounds = xx.odc.add_to(None, cmap=cmap, max_size=32, fmt="jpeg", quality=50)
+    assert isinstance(url, str)
+    assert url.startswith("data:")
+    assert "image/jpeg" in url
+    assert isinstance(bounds, tuple)
+    assert isinstance(bounds[0], tuple)
+    assert isinstance(bounds[0], tuple)
+
+    for not_a_map in [xx.data, {}, []]:
+        with pytest.raises(ValueError):
+            _ = xx.odc.add_to(not_a_map)
+
+
+@pytest.mark.sckipif(have.folium is False, reason="No folium installed")
+def test_add_to_folium(ocean_raster: xr.DataArray):
+    import folium
+
+    xx = ocean_raster.copy()[20:-20]
+    assert isinstance(xx.odc, ODCExtensionDa)
+
+    m = folium.Map()
+    img_overlay = xx.odc.add_to(m, cmap=cmap, max_size=32, zlevel=1)
+    assert img_overlay is not None
+
+
+@pytest.mark.sckipif(have.ipyleaflet is False, reason="No ipyleaflet installed")
+def test_add_to_ipyleaflet(ocean_raster: xr.DataArray):
+    import ipyleaflet
+
+    xx = ocean_raster.copy()[20:-20]
+    assert isinstance(xx.odc, ODCExtensionDa)
+
+    m = ipyleaflet.Map()
+    img_overlay = xx.odc.add_to(m, cmap=cmap, max_size=32, name="xx")
+    assert img_overlay is not None

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -40,7 +40,7 @@ def test_add_to(ocean_raster: xr.DataArray):
             _ = xx.odc.add_to(not_a_map)
 
 
-@pytest.mark.sckipif(have.folium is False, reason="No folium installed")
+@pytest.mark.skipif(have.folium is False, reason="No folium installed")
 def test_add_to_folium(ocean_raster: xr.DataArray):
     import folium
 
@@ -52,7 +52,7 @@ def test_add_to_folium(ocean_raster: xr.DataArray):
     assert img_overlay is not None
 
 
-@pytest.mark.sckipif(have.ipyleaflet is False, reason="No ipyleaflet installed")
+@pytest.mark.skipif(have.ipyleaflet is False, reason="No ipyleaflet installed")
 def test_add_to_ipyleaflet(ocean_raster: xr.DataArray):
     import ipyleaflet
 

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -452,6 +452,7 @@ def test_compute_output_geobox():
     assert dst.crs == "epsg:6933"
     assert dst.resolution == src.resolution
     assert dst.geographic_extent.contains(src.geographic_extent)
+    assert compute_output_geobox(src, "epsg:6933") == src.to_crs("epsg:6933")
 
     assert compute_output_geobox(
         src, "epsg:6933", resolution="auto"

--- a/tests/test_rgba.py
+++ b/tests/test_rgba.py
@@ -1,0 +1,126 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from odc.geo._interop import is_dask_collection
+from odc.geo._rgba import is_rgb
+from odc.geo.data import ocean_geom
+from odc.geo.geobox import GeoBox
+from odc.geo.testutils import daskify
+from odc.geo.xr import ODCExtensionDa, ODCExtensionDs, rasterize
+
+
+@pytest.fixture()
+def ocean_raster() -> xr.DataArray:
+    gbox = GeoBox.from_bbox(bbox=(-180, -90, 180, 90), shape=(128, 256))
+    return rasterize(ocean_geom(), gbox)
+
+
+@pytest.fixture()
+def ocean_raster_ds(ocean_raster: xr.DataArray) -> xr.Dataset:
+    xx = ocean_raster.astype("int16") * 3_000
+    xx.attrs["nodata"] = -1
+
+    return xr.Dataset(
+        dict(
+            red=xx,
+            green=xx,
+            blue=xx,
+        )
+    )
+
+
+def test_colorize(ocean_raster: xr.DataArray):
+    xx = ocean_raster
+
+    assert isinstance(xx.odc, ODCExtensionDa)
+    cmap = np.asarray(
+        [
+            [153, 153, 102, 255],
+            [51, 102, 153, 255],
+        ],
+        dtype="uint8",
+    )
+
+    cc = xx.odc.colorize(cmap)
+    assert isinstance(cc.odc, ODCExtensionDa)
+    assert cc.odc.geobox == xx.odc.geobox
+    assert cc.dtype == cmap.dtype
+    assert cc.shape == (*xx.shape, 4)
+
+    cc = xx.astype("int16").odc.colorize(cmap, clip=True)
+    assert isinstance(cc.odc, ODCExtensionDa)
+    assert cc.odc.geobox == xx.odc.geobox
+    assert cc.dtype == cmap.dtype
+    assert cc.shape == (*xx.shape, 4)
+
+    _xx = daskify(xx, chunks=(16, 32))
+    assert is_dask_collection(_xx) is True
+
+    _cc = _xx.odc.colorize(cmap, clip=True)
+    assert is_dask_collection(_cc) is True
+
+    assert isinstance(_cc.odc, ODCExtensionDa)
+    assert _cc.odc.geobox == _xx.odc.geobox
+    assert _cc.dtype == cmap.dtype
+    assert _cc.shape == (*_xx.shape, 4)
+
+    assert bool((_cc.compute() == cc).all()) is True
+
+
+def test_rgba(ocean_raster_ds: xr.Dataset):
+    xx = ocean_raster_ds
+    assert xx.red.dtype == "int16"
+    assert isinstance(xx.odc, ODCExtensionDs)
+    assert xx.red.nodata == -1
+
+    cc = xx.odc.to_rgba((0, 3_000))
+    assert isinstance(cc.odc, ODCExtensionDa)
+    assert cc.odc.geobox == xx.odc.geobox
+    assert cc.dtype == "uint8"
+    assert cc.shape == (*xx.red.shape, 4)
+    assert is_rgb(cc) is True
+    assert is_rgb(xx.red) is False
+
+    cc = xx.astype("float32").odc.to_rgba()
+    assert isinstance(cc.odc, ODCExtensionDa)
+    assert cc.odc.geobox == xx.odc.geobox
+    assert cc.dtype == "uint8"
+    assert cc.shape == (*xx.red.shape, 4)
+
+    _xx = xx.rename(dict(red="b1", green="b2", blue="b3"))
+    for dv in _xx.data_vars.values():
+        dv.attrs.pop("nodata", None)
+
+    cc = _xx.odc.to_rgba(3_000, bands=["b1", "b2", "b3"])
+    assert isinstance(cc.odc, ODCExtensionDa)
+    assert cc.odc.geobox == xx.odc.geobox
+    assert cc.dtype == "uint8"
+    assert cc.shape == (*xx.red.shape, 4)
+    assert is_rgb(cc[..., 0]) is False
+    assert is_rgb(cc[..., :2]) is False
+    assert is_rgb(cc[..., :3]) is True
+
+    # can't guess band names
+    with pytest.raises(ValueError):
+        _ = _xx.odc.to_rgba(3_000)
+
+    # too many red band candidates
+    _xx = xx.rename({"red": "red1"})
+    _xx["red2"] = xx.red
+    with pytest.raises(ValueError):
+        _ = _xx.odc.to_rgba(3_000)
+
+    _xx = daskify(xx, chunks=(51, 39))
+    assert is_dask_collection(_xx) is True
+    _cc = _xx.odc.to_rgba(clamp=3000)
+    assert isinstance(_cc.odc, ODCExtensionDa)
+    assert is_dask_collection(_cc) is True
+    assert _cc.odc.geobox == xx.odc.geobox
+    assert _cc.dtype == "uint8"
+    assert _cc.shape == (*xx.red.shape, 4)
+    assert bool((cc == _cc.compute()).all()) is True
+
+    # missing clamp for dask inputs
+    with pytest.raises(ValueError):
+        _ = _xx.odc.to_rgba()

--- a/tests/test_rgba.py
+++ b/tests/test_rgba.py
@@ -124,3 +124,17 @@ def test_rgba(ocean_raster_ds: xr.Dataset):
     # missing clamp for dask inputs
     with pytest.raises(ValueError):
         _ = _xx.odc.to_rgba()
+
+    # smoke-test compression
+    assert isinstance(cc.odc.compress("jpeg", 60, transparent=(0, 0, 0)), bytes)
+    assert isinstance(_cc.odc.compress("png", 9), bytes)
+    assert isinstance(cc.odc.compress(as_data_url=True), str)
+
+    assert isinstance(xx.red.astype("uint8").odc.compress(), bytes)
+
+    with pytest.raises(ValueError):
+        _ = xx.red.odc.compress("no-such-format")
+
+    with pytest.raises(ValueError):
+        # expect 2d/3d inputs
+        _ = xx.red[0].odc.compress()

--- a/tests/test_rgba.py
+++ b/tests/test_rgba.py
@@ -4,30 +4,8 @@ import xarray as xr
 
 from odc.geo._interop import is_dask_collection
 from odc.geo._rgba import is_rgb
-from odc.geo.data import ocean_geom
-from odc.geo.geobox import GeoBox
 from odc.geo.testutils import daskify
-from odc.geo.xr import ODCExtensionDa, ODCExtensionDs, rasterize
-
-
-@pytest.fixture()
-def ocean_raster() -> xr.DataArray:
-    gbox = GeoBox.from_bbox(bbox=(-180, -90, 180, 90), shape=(128, 256))
-    return rasterize(ocean_geom(), gbox)
-
-
-@pytest.fixture()
-def ocean_raster_ds(ocean_raster: xr.DataArray) -> xr.Dataset:
-    xx = ocean_raster.astype("int16") * 3_000
-    xx.attrs["nodata"] = -1
-
-    return xr.Dataset(
-        dict(
-            red=xx,
-            green=xx,
-            blue=xx,
-        )
-    )
+from odc.geo.xr import ODCExtensionDa, ODCExtensionDs
 
 
 def test_colorize(ocean_raster: xr.DataArray):

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -5,9 +5,9 @@
 import numpy as np
 import pytest
 import xarray as xr
-from dask import is_dask_collection
 
 from odc.geo import geom
+from odc.geo._interop import is_dask_collection
 from odc.geo.data import ocean_geom
 from odc.geo.geobox import GeoBox
 from odc.geo.testutils import epsg3577, mkA, purge_crs_info
@@ -377,3 +377,12 @@ def test_xr_rasterize():
     )
     assert xx.odc.geobox.crs == "epsg:3857"
     assert xx.any().item() is False
+
+
+def test_is_dask_collection():
+    import dask
+
+    import odc.geo._interop
+
+    assert "is_dask_collection" in dir(odc.geo._interop)
+    assert is_dask_collection is dask.is_dask_collection

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -91,6 +91,8 @@ def test_xr_zeros(geobox_epsg4326: GeoBox):
     assert (xx.values == 0).all()
     assert xx.spatial_ref.attrs["spatial_ref"] == gbox.crs.wkt
     assert xx.spatial_ref.attrs["grid_mapping_name"] == "latitude_longitude"
+    assert xx.odc.ydim == 0
+    assert xx.odc.xdim == 1
 
     # check custom name for crs coordinate
     xx = xr_zeros(gbox, dtype="uint16", crs_coord_name="_crs")
@@ -122,6 +124,8 @@ def test_xr_zeros(geobox_epsg4326: GeoBox):
     assert xx.dtype == "uint16"
     assert xx.data.chunksize == (1, 10, 20)
     assert xx.shape == (2, *gbox.shape)
+    assert xx.odc.ydim == 1
+    assert xx.odc.xdim == 2
 
 
 def test_purge_crs_info(xx_epsg4326: xr.DataArray):


### PR DESCRIPTION
To do that had to

1. Add conversion to rgb(a)
2. Generalize reproject to support multi-band inputs (any number of dimensions really)
3. Add compression to PNG/JPEG/WEBP
4. Add bounds computation for a "web map format" `((lat1, lon1), (lat2, lon2))`  for the two corners.
5. Tweak GeoBox construction and zoom_to methods to support "no side more than max pixels" option
6. Add `Geobox.to_crs` method
7. Add `.aspect` methods


TODO: support matplotlib colormaps when available.
TODO: docs


