### PR TITLE
account for `src_nodata` kwarg in `xr_reproject`

### DIFF
--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -386,7 +386,9 @@ def xr_reproject(
     dst_shape = (*src.shape[:ydim], *dst_geobox.shape, *src.shape[ydim + 2 :])
 
     dst = numpy.empty(dst_shape, dtype=src.dtype)
-    src_nodata = src.attrs.get("nodata", None)
+    src_nodata = kw.pop("src_nodata", None)
+    if src_nodata is None:
+        src_nodata = src.attrs.get("nodata", None)
     if dst_nodata is None:
         dst_nodata = src_nodata
 


### PR DESCRIPTION
Passing in `src_nodata` as kwarg in `odc.reproject` raises a `TypeError`. 

Example:

```python
import xarray as xr
from numpy.random import uniform
from odc.geo.data import country_geom
from odc.geo.xr import rasterize

# Make some sample images
def gen_sample(iso3, crs="epsg:3857", res=60_000, vmin=0, vmax=1000):
    xx = rasterize(country_geom(iso3, crs), res)
    return xr.where(xx, uniform(vmin, vmax, size=xx.shape), float("nan")).astype("float32")

aus = gen_sample("AUS")
aus.odc.reproject(aus.odc.geobox.zoom_out(1), src_nodata=0)
```
Result:

> ```python 
>TypeError: rio_reproject() got multiple values for keyword argument 'src_nodata'

The changes in this PR account for the kwarg, and give it precedence with the assumption the user wants to manually override it.