### PR TITLE
Handle GeoBoxes and Geometries that do not project cleanly

### DIFF
--- a/odc/geo/_version.py
+++ b/odc/geo/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -485,7 +485,7 @@ class GeoBox:
             buffer = buffer * max(*self.resolution.xy)
             ext = ext.buffer(buffer)
 
-        return ext.to_crs(crs, resolution=self._reproject_resolution(npoints))
+        return ext.to_crs(crs, resolution=self._reproject_resolution(npoints)).dropna()
 
     @property
     def geographic_extent(self) -> Geometry:
@@ -786,7 +786,7 @@ class GeoBox:
 
         dx, dy = self._affine * (step, 0)
         res = math.sqrt(dx * dx + dy * dy) / 5
-        return lines.to_crs("epsg:4326", resolution=res)
+        return lines.to_crs("epsg:4326", resolution=res).dropna()
 
     def outline(self, mode: OutlineMode = "native", notch: float = 0.1) -> Geometry:
         """
@@ -838,7 +838,7 @@ class GeoBox:
         bbox = native.boundingbox
         res = max(bbox.span_x, bbox.span_y) / 100
 
-        return native.to_crs("EPSG:4326", resolution=res)
+        return native.to_crs("EPSG:4326", resolution=res).dropna()
 
     def _display_bbox(self, pad_fraction: float = 0.1):
         bbox = self.geographic_extent.boundingbox

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -409,8 +409,6 @@ class Geometry(SupportsCoords[float]):
     @property
     def wkt(self) -> str: return self.geom.wkt
     @property
-    def __array_interface__(self): return self.geom.__array_interface__
-    @property
     def __geo_interface__(self): return self.geom.__geo_interface__
     # fmt: on
 

--- a/odc/geo/math.py
+++ b/odc/geo/math.py
@@ -7,7 +7,7 @@ Various mathy helpers.
 
 Minimal dependencies in this module.
 """
-from math import ceil, floor, fmod
+from math import ceil, floor, fmod, isfinite
 from typing import List, Literal, Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
@@ -36,6 +36,9 @@ def split_float(x: float) -> Tuple[float, float]:
     :param x: floating point number
     :return: ``whole, fraction``
     """
+    if not isfinite(x):
+        return (x, 0)
+
     x_part = fmod(x, 1.0)
     x_whole = x - x_part
     if x_part > 0.5:
@@ -53,6 +56,8 @@ def maybe_int(x: float, tol: float) -> Union[int, float]:
 
     pass through other values unmodified.
     """
+    if not isfinite(x):
+        return x
 
     x_whole, x_part = split_float(x)
 
@@ -119,6 +124,9 @@ def is_almost_int(x: float, tol: float) -> bool:
     :param x: number to check
     :param tol: tolerance to use.
     """
+    if not isfinite(x):
+        return False
+
     x = abs(fmod(x, 1))
     if x > 0.5:
         x = 1 - x

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -313,7 +313,7 @@ def _norm_slice(s: SomeSlice, n: int) -> NormalizedSlice:
 @overload
 def roi_normalise(roi: SomeSlice, shape: Union[int, Tuple[int]]) -> NormalizedSlice: ...
 @overload
-def roi_normalise( roi: Tuple[SomeSlice, ...], shape: Tuple[int, ...]
+def roi_normalise(roi: Tuple[SomeSlice, ...], shape: Tuple[int, ...]
 ) -> Tuple[NormalizedSlice, ...]: ...
 # fmt: on
 
@@ -352,7 +352,7 @@ def roi_normalise(
 @overload
 def roi_pad(roi: SomeSlice, pad: int, shape: int) -> NormalizedSlice: ...
 @overload
-def roi_pad(roi: Tuple[SomeSlice,...], pad: int, shape: Tuple[int, ...]) -> Tuple[NormalizedSlice, ...]: ...
+def roi_pad(roi: Tuple[SomeSlice, ...], pad: int, shape: Tuple[int, ...]) -> Tuple[NormalizedSlice, ...]: ...
 # fmt: on
 
 
@@ -474,6 +474,16 @@ def roi_from_points(
 
     assert len(shape) == 2
     assert xy.ndim == 2 and xy.shape[1] == 2
+
+    # keep finite points only
+    #  if any points are not finite remove them
+    ok_mask = np.isfinite(xy)
+    if not ok_mask.all():
+        keep = ok_mask.T[0] * ok_mask.T[1]
+        xy = xy[keep, :]
+
+    if xy.shape[0] == 0:
+        return np.s_[0:0, 0:0]
 
     ny, nx = shape
 

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -190,11 +190,6 @@ def test_ops():
         with pytest.raises(TypeError):
             pt.interpolate(3)
 
-    # test array interface
-    with pytest.warns(ShapelyDeprecationWarning):
-        assert line.__array_interface__ is not None
-        assert np.array(line).shape == (3, 2)
-
     # test simplify
     poly = geom.polygon([(0, 0), (0, 5), (10, 5)], epsg4326)
     assert poly.simplify(100) == poly


### PR DESCRIPTION
- Add `.filter` and `.dropna` to geometry class
- Don't crash when displaying GeoBoxes that do not project cleanly to `epsg:4326`
- Handle nan/inf inputs in `maybe_int` and `split_float`
- Remove `__array_interface__` from geometry class, it will be removed from shapely too and is not used anywhere that I can tell
- make release

### Example

Displaying geobox that goes off to infinity that used to raise an error previously:

<img width="608" alt="Screen Shot 2022-08-11 at 4 09 27 pm" src="https://user-images.githubusercontent.com/1428024/184073825-5cd35fc5-1864-4253-a774-780c4e0aadeb.png">


### Related to

https://github.com/opendatacube/odc-stac/issues/85