### PR TITLE
Add GCPGeoBox

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,6 +31,7 @@ Interfacing with :py:class:`xarray.DataArray` and :py:class:`xarray.Dataset` cla
    ODCExtensionDa.compress
    ODCExtensionDa.ydim
    ODCExtensionDa.xdim
+   ODCExtensionDa.nodata
 
    ODCExtensionDs
    ODCExtensionDs.to_rgba

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -422,7 +422,7 @@ def xr_reproject(
     dst = numpy.empty(dst_shape, dtype=src.dtype)
     src_nodata = kw.pop("src_nodata", None)
     if src_nodata is None:
-        src_nodata = src.attrs.get("nodata", None)
+        src_nodata = src.odc.nodata
     if dst_nodata is None:
         dst_nodata = src_nodata
 
@@ -441,6 +441,7 @@ def xr_reproject(
     attrs = src.attrs.copy()
     if dst_nodata is None:
         attrs.pop("nodata", None)
+        attrs.pop("_FillValue", None)
     else:
         attrs.update(nodata=dst_nodata)
 
@@ -538,6 +539,17 @@ class ODCExtensionDa(ODCExtension):
     ) -> xarray.DataArray:
         """See :py:meth:`odc.geo.xr.assign_crs`."""
         return assign_crs(self._xx, crs=crs, crs_coord_name=crs_coord_name)
+
+    @property
+    def nodata(self) -> Optional[float]:
+        """Extract ``nodata/_FillValue`` attribute if set."""
+        attrs = self._xx.attrs
+        for k in ["nodata", "_FillValue"]:
+            nodata = attrs.get(k, None)
+            if nodata is not None:
+                return float(nodata)
+
+        return None
 
     colorize = _wrap_op(colorize)
 

--- a/odc/geo/gcp.py
+++ b/odc/geo/gcp.py
@@ -185,6 +185,19 @@ class GCPGeoBox(GeoBoxBase):
         """
         return self[self.shape.map(lambda x: x // 2).yx]
 
+    def map_bounds(self) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+        """
+        Query bounds in folium/ipyleaflet style.
+
+        Returns SW, and NE corners in lat/lon order.
+        ``((lat_w, lon_s), (lat_e, lon_n))``.
+        """
+        if self._crs is not None:
+            x0, y0, x1, y1 = self.geographic_extent.boundingbox.bbox
+        else:
+            x0, y0, x1, y1 = self.extent.boundingbox.bbox
+        return (y0, x0), (y1, x1)
+
     def pad(self, padx: int, pady: MaybeInt = None) -> "GCPGeoBox":
         """
         Pad geobox.

--- a/odc/geo/gcp.py
+++ b/odc/geo/gcp.py
@@ -1,0 +1,273 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2022 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+from affine import Affine
+
+from .crs import CRS, MaybeCRS, norm_crs
+from .geobox import GeoBox, GeoBoxBase
+from .geom import Geometry, multipoint
+from .math import Poly2d, affine_from_pts, align_up, resolution_from_affine, unstack_xy
+from .types import XY, MaybeInt, Resolution, SomeShape, wh_
+
+SomePointSet = Union[np.ndarray, Geometry, List[Geometry], List[XY[float]]]
+
+
+def _points_to_array(pts: SomePointSet) -> Tuple[np.ndarray, Optional[CRS]]:
+    if isinstance(pts, np.ndarray):
+        return pts, None
+    if isinstance(pts, Geometry):
+        return np.asarray([pt.coords[0] for pt in pts.geoms]), pts.crs
+
+    def _xy(pt: Union[Geometry, XY[float]]) -> Tuple[float, float]:
+        if isinstance(pt, Geometry):
+            ((x, y),) = pt.coords
+        else:
+            x, y = pt.xy
+        return (x, y)
+
+    crs = getattr(pts[0], "crs", None)
+    return np.asarray([_xy(pt) for pt in pts]), crs
+
+
+class GCPMapping:
+    """
+    Shared state for GCPGeoBox.
+    """
+
+    def __init__(
+        self,
+        pix: SomePointSet,
+        wld: SomePointSet,
+        crs: MaybeCRS = None,
+    ):
+        pix, _ = _points_to_array(pix)
+        wld, _crs = _points_to_array(wld)
+
+        if crs is None:
+            crs = _crs
+
+        # Nx2
+        assert pix.shape == wld.shape
+        assert pix.shape[1] == 2
+
+        self._pix = pix
+        self._wld = wld
+        self._crs = norm_crs(crs)
+        self._approx_affine: Optional[Affine] = None
+
+        self._p2w: Optional[Poly2d] = None
+        self._w2p: Optional[Poly2d] = None
+
+    @property
+    def p2w(self) -> Poly2d:
+        """Pixel to world."""
+        if self._p2w is not None:
+            return self._p2w
+
+        self._p2w = Poly2d.fit(self._pix, self._wld)
+        return self._p2w
+
+    @property
+    def w2p(self) -> Poly2d:
+        """World to pixel."""
+        if self._w2p is not None:
+            return self._w2p
+
+        self._w2p = Poly2d.fit(self._wld, self._pix)
+        return self._w2p
+
+    @property
+    def crs(self) -> Optional[CRS]:
+        return self._crs
+
+    @property
+    def approx(self) -> Affine:
+        if self._approx_affine is not None:
+            return self._approx_affine
+
+        pix = unstack_xy(self._pix)
+        wld = unstack_xy(self._wld)
+        self._approx_affine = affine_from_pts(pix, wld)
+
+        return self._approx_affine
+
+    @property
+    def resolution(self) -> Resolution:
+        """Resolution, pixel size in CRS units."""
+        return resolution_from_affine(self.approx)
+
+    def points(self) -> Tuple[Geometry, Geometry]:
+        """Return multipoint geometries for (Pixel, World)."""
+        return (
+            multipoint(self._pix.tolist(), None),
+            multipoint(self._wld.tolist(), self.crs),
+        )
+
+    def __dask_tokenize__(self):
+        return (
+            "odc.geo._gcp.GCPMapping",
+            str(self._crs),
+            self._wld,
+            self._pix,
+        )
+
+    @staticmethod
+    def from_rio(src, output_crs: MaybeCRS = None) -> "GCPMapping":
+        """
+        Construct from an open rasterio file.
+        """
+        # pylint: disable=import-outside-toplevel
+        from .converters import extract_gcps
+
+        return GCPMapping(*extract_gcps(src, output_crs))
+
+
+class GCPGeoBox(GeoBoxBase):
+    """
+    Ground Control Point based GeoBox.
+
+    """
+
+    __slots__ = ("_mapping",)
+
+    def __init__(
+        self, shape: SomeShape, mapping: GCPMapping, affine: Optional[Affine] = None
+    ):
+        if affine is None:
+            affine = Affine.identity()
+        GeoBoxBase.__init__(self, shape, affine, mapping.crs)
+        self._mapping = mapping
+
+    def __getitem__(self, roi) -> "GCPGeoBox":
+        _shape, _affine = self.compute_crop(roi)
+        return GCPGeoBox(shape=_shape, mapping=self._mapping, affine=_affine)
+
+    @property
+    def approx(self) -> GeoBox:
+        """
+        Compute best fitting linear GeoBox.
+        """
+        return GeoBox(self.shape, self._mapping.approx * self._affine, self.crs)
+
+    @property
+    def resolution(self) -> Resolution:
+        """Resolution, pixel size in CRS units."""
+        return self.approx.resolution
+
+    def wld2pix(self, x, y):
+        x, y = self._mapping.w2p(x, y)
+        return (~self._affine) * (x, y)
+
+    def pix2wld(self, x, y):
+        x, y = self._affine * (x, y)
+        wx, wy = self._mapping.p2w(x, y)
+        return (wx, wy)
+
+    def __hash__(self):
+        return hash((*self._shape, self._affine, self._crs, id(self._mapping)))
+
+    @property
+    def linear(self) -> bool:
+        return False
+
+    @property
+    def axis_aligned(self):
+        return False
+
+    @property
+    def center_pixel(self) -> "GCPGeoBox":
+        """
+        GeoBox of a center pixel.
+        """
+        return self[self.shape.map(lambda x: x // 2).yx]
+
+    def pad(self, padx: int, pady: MaybeInt = None) -> "GCPGeoBox":
+        """
+        Pad geobox.
+
+        Expand GeoBox by fixed number of pixels on each side
+        """
+        # false positive for -pady, it's never None by the time it runs
+        # pylint: disable=invalid-unary-operand-type
+
+        pady = padx if pady is None else pady
+
+        ny, nx = self._shape.yx
+        A = self._affine * Affine.translation(-padx, -pady)
+        shape = (ny + pady * 2, nx + padx * 2)
+        return GCPGeoBox(shape, self._mapping, A)
+
+    def pad_wh(self, alignx: int = 16, aligny: MaybeInt = None) -> "GCPGeoBox":
+        """
+        Possibly expand :py:class:`~odc.geo.geobox.GeoBox` by a few pixels.
+
+        Find nearest ``width``/``height`` that are multiples of the desired factor. And return a new
+        geobox that is slighly taller and/or wider covering roughly the same region. The new geobox
+        will have the same CRS and transform but possibly larger shape.
+        """
+        aligny = alignx if aligny is None else aligny
+        ny, nx = (align_up(sz, n) for sz, n in zip(self._shape.yx, (aligny, alignx)))
+
+        return GCPGeoBox((ny, nx), self._mapping, self._affine)
+
+    def zoom_out(self, factor: float) -> "GCPGeoBox":
+        """
+        Compute :py:class:`~odc.geo.geobox.GCPGeoBox` with changed resolution.
+
+        - ``factor > 1`` implies smaller width/height, fewer but bigger pixels
+        - ``factor < 1`` implies bigger width/height, more but smaller pixels
+
+        :returns:
+           GCPGeoBox covering the same region but with different pixels (i.e. lower or higher resolution)
+        """
+        _shape, _affine = self.compute_zoom_out(factor)
+        return GCPGeoBox(_shape, self._mapping, _affine)
+
+    def zoom_to(self, shape: Union[SomeShape, int, float]) -> "GCPGeoBox":
+        """
+        Compute :py:class:`~odc.geo.geobox.GCPGeoBox` with changed resolution.
+
+        When supplied a single integer scale longest dimension to match that.
+
+        :returns:
+          GCPGeoBox covering the same region but with different number of pixels and therefore resolution.
+        """
+        _shape, _affine = self.compute_zoom_to(shape)
+        return GCPGeoBox(_shape, self._mapping, _affine)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __repr__(self) -> str:
+        return f"GCPGeoBox({self._shape.xy!r}, {self.crs!r})"
+
+    def __eq__(self, __o: object) -> bool:
+        if not isinstance(__o, GCPGeoBox):
+            return False
+
+        return (
+            self._shape == __o.shape
+            and self._mapping is __o._mapping
+            and self._affine == __o._affine
+        )
+
+    def __dask_tokenize__(self):
+        return (
+            "odc.geo._gcp.GCPGeoBox",
+            *self._mapping.__dask_tokenize__()[1:],
+            *self._shape.yx,
+            *self._affine[:6],
+        )
+
+    @staticmethod
+    def from_rio(src, output_crs: MaybeCRS = None) -> "GCPGeoBox":
+        """
+        Construct from an open rasterio file.
+        """
+        return GCPGeoBox(
+            wh_(src.width, src.height), GCPMapping.from_rio(src, output_crs)
+        )

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -820,7 +820,7 @@ class GeoBox(GeoBoxBase):
         )
 
 
-def gbox_boundary(gbox: GeoBox, pts_per_side: int = 16) -> numpy.ndarray:
+def gbox_boundary(gbox: GeoBoxBase, pts_per_side: int = 16) -> numpy.ndarray:
     """Alias for :py:meth:`odc.geo.geobox.GeoBox.boundary`."""
     return gbox.boundary(pts_per_side)
 

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -712,9 +712,15 @@ class Geometry(SupportsCoords[float]):
         """
 
         if self.type == "Polygon":
-            # TODO: deal with interior rings
             pts = [(x, y) for x, y in self.exterior.points if pred(x, y)]
-            return polygon(pts, self.crs)
+            # prune inner polygon points
+            inners = [
+                [(x, y) for x, y in ring.points if pred(x, y)]
+                for ring in self.interiors
+            ]
+            # prune inner polygons that don't have enough points
+            inners = [ring for ring in inners if len(ring) >= 3]
+            return polygon(pts, self.crs, *inners)
 
         if self.type in ("LinearRing", "LineString"):
             pts = [(x, y) for x, y in self.points if pred(x, y)]

--- a/odc/geo/overlap.py
+++ b/odc/geo/overlap.py
@@ -395,8 +395,8 @@ def _can_paste(
 
 
 def _relative_rois(
-    src: GeoBox,
-    dst: GeoBox,
+    src: GeoBoxBase,
+    dst: GeoBoxBase,
     tr: PointTransform,
     pts_per_side: int,
     padding: int,
@@ -417,8 +417,8 @@ def _relative_rois(
 
 
 def compute_reproject_roi(
-    src: GeoBox,
-    dst: GeoBox,
+    src: GeoBoxBase,
+    dst: GeoBoxBase,
     ttol: float = 0.05,
     stol: float = 1e-3,
     padding: Optional[int] = None,
@@ -531,6 +531,7 @@ def compute_reproject_roi(
             roi_src, roi_dst = box_overlap(src.shape, dst.shape, A_)
         else:
             # compute overlap in scaled down image, then upscale source overlap
+            assert isinstance(src, GeoBox)
             _src = src.zoom_out(read_shrink)
             A_ = snap_affine(Affine.scale(1 / read_shrink) * A, ttol=ttol, stol=stol)
             roi_src, roi_dst = box_overlap(_src.shape, dst.shape, A_)

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -434,3 +434,7 @@ ROI = Tuple[SomeSlice, SomeSlice]
 
 NormalizedROI = Tuple[NormalizedSlice, NormalizedSlice]
 """Normalized 2d slice into an image plane."""
+
+OutlineMode = Union[
+    Literal["native"], Literal["pixel"], Literal["geo"], Literal["auto"]
+]

--- a/odc/geo/ui.py
+++ b/odc/geo/ui.py
@@ -1,12 +1,14 @@
+import itertools
 import math
 from functools import lru_cache
-from typing import Tuple
+from textwrap import dedent
+from typing import Any, Optional, Tuple
 
 from . import geom
-from .data import ocean_geom
-from .types import XY, Shape2d, wh_, xy_
+from .crs import CRS
+from .types import XY, OutlineMode, Shape2d, wh_, xy_
 
-# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals,import-outside-toplevel
 _UNIT_REMAPS = {
     "metre": "m",
     "meter": "m",
@@ -42,6 +44,8 @@ def pick_grid_step(N: int, at_least: int = 4, no_more: int = 11) -> int:
 
 @lru_cache
 def _ocean_svg_path(ndecimal=3, clip_bbox=None):
+    from .data import ocean_geom
+
     g = ocean_geom()
     if clip_bbox is not None:
         g = g & geom.box(*clip_bbox, crs=g.crs)
@@ -166,3 +170,220 @@ def make_svg(
 <g transform="matrix({s},0,0,{-s},{-x0*s},{y1*s})">
 {more_svg}
 </g></svg>"""
+
+
+class PixelGridDisplay:
+    """
+    Common code for visualization of geoboxes.
+
+    """
+
+    def __init__(
+        self,
+        src: Any,
+        pix2world: Any,
+        gsd: float,
+    ) -> None:
+        self._src = src
+        self._shape: Shape2d = src.shape
+        self._crs: Optional[CRS] = src.crs
+        self._pix2world = pix2world
+        self._gsd = gsd
+
+    def svg(
+        self,
+        scale_factor: float = 1.0,
+        mode: OutlineMode = "auto",
+        notch: float = 0.0,
+        grid_stroke: str = "pink",
+    ) -> str:
+        """
+        Produce SVG paths.
+
+        :param mode: One of pixel, native, geo (default is geo)
+        :return: SVG path
+        """
+        if mode == "auto":
+            mode = "native" if self._crs is None else "geo"
+
+        grids = self.grid_lines(mode=mode)
+        outline = self.outline(mode, notch=notch)
+
+        grid_svg = (
+            '<path fill="none" opacity="0.8"'
+            f' stroke-width="{0.8*scale_factor}"'
+            f' stroke="{grid_stroke}"'
+            f' d="{grids.svg_path()}" />'
+        )
+
+        return outline.svg(scale_factor) + grid_svg
+
+    def grid_lines(self, step: int = 0, mode: OutlineMode = "native") -> geom.Geometry:
+        """
+        Construct pixel edge aligned grid lines.
+        """
+
+        nx, ny = self._shape.xy
+        if nx > 0 and ny > 0:
+            if step == 0:
+                step = pick_grid_step(max(nx, ny))
+            xx = [*range(0, nx, step), nx]
+            yy = [*range(0, ny, step), ny]
+            vertical = [list(itertools.product([x], yy)) for x in xx[1:-1]]
+            horizontal = [list(itertools.product(xx, [y])) for y in yy[1:-1]]
+            lines = geom.multiline(vertical + horizontal, self._crs)
+        else:
+            lines = geom.multiline([], self._crs)
+
+        if mode == "pixel":
+            return lines
+
+        lines = lines.transform(self._pix2world)
+        if mode == "native":
+            return lines
+
+        dx, dy = self._pix2world(step, 0)
+        res = math.sqrt(dx * dx + dy * dy) / 5
+        return lines.to_crs("epsg:4326", resolution=res).dropna()
+
+    def outline(
+        self, mode: OutlineMode = "native", notch: float = 0.1
+    ) -> geom.Geometry:
+        """
+        Produce Line Geometry around perimeter.
+
+        .. code-block:: txt
+
+             +---+-------------+
+             |   |             |
+             +---+             |
+             |                 |
+             |                 |
+             +-----------------+
+        """
+
+        assert notch < 1
+        w, h = self._shape.wh
+        if notch > 0:
+            nn = min(notch * max(w, h), w, h)
+            pix = geom.line(
+                [
+                    (0, nn),
+                    (0, 0),
+                    (nn, 0),
+                    (w, 0),
+                    (w, h),
+                    (0, h),
+                    (0, nn),
+                    (nn, nn),
+                    (nn, 0),
+                ],
+                self._crs,
+            )
+        else:
+            pix = geom.multigeom(
+                [
+                    geom.line([(0, 0), (w, 0), (w, h), (0, h), (0, 0)], self._crs),
+                    geom.point(0, 0, self._crs),
+                ]
+            )
+        if mode == "pixel":
+            return pix
+
+        native = pix.transform(self._pix2world)
+        if mode == "native":
+            return native
+
+        # about 100 pts per side
+        bbox = native.boundingbox
+        res = max(bbox.span_x, bbox.span_y) / 100
+
+        return native.to_crs("EPSG:4326", resolution=res).dropna()
+
+    def _display_bbox(self, pad_fraction: float = 0.1):
+        bbox = self._src.geographic_extent.boundingbox
+        pad_deg = max(bbox.span_x, bbox.span_y) * pad_fraction
+        return bbox.buffered(pad_deg)
+
+    def _render_svg(self, sz=360):
+
+        if self._crs is None:
+            bbox = self._src.extent.boundingbox
+            margin = 0.1 * max(bbox.span_x, bbox.span_y)
+            bbox = bbox.buffered(margin)
+            return make_svg(
+                self,
+                bbox=bbox,
+                sz=sz,
+            )
+
+        return svg_base_map(self, bbox=self._display_bbox(), sz=sz)
+
+    def _repr_svg_(self):
+        return self._render_svg()
+
+    def _repr_html_(self):
+        from .data import gbox_css
+
+        W, H = self._shape.wh
+        grid_step = pick_grid_step(max(W, H))
+        svg_zoomed_txt = self._render_svg(sz=320)
+
+        crs = self._crs
+        if crs is None:
+            authority = ("", "")
+            wkt = "not set"
+            units = ""
+            svg_global_txt = ""
+        else:
+            authority = crs.authority
+            wkt = crs.to_wkt(pretty=True).replace("\n", "<br/>").replace(" ", "&nbsp;")
+            units = crs.units[0]
+            svg_global_txt = svg_base_map(
+                sz=200, target=self._src.geographic_extent.centroid.coords[0]
+            )
+
+        if authority == ("", ""):
+            authority = ("CRS", "WKT")
+
+        units = norm_units(units)
+        pix_sz = self._gsd
+
+        info = [
+            ("Dimensions", f"{W:,d}x{H:,d}"),
+            authority,
+            ("Resolution", f"{pix_sz:g}{units}"),
+            ("Cell", f"{grid_step:,d}px"),
+        ]
+
+        info_html = "\n".join(
+            [
+                (
+                    f'<div class="row"><div class="column">{hdr}</div>'
+                    f'<div class="column value">{val}</div></div>'
+                )
+                for hdr, val in info
+            ]
+        )
+        src_class_name = type(self._src).__name__
+
+        return dedent(
+            f"""\
+        <style>{gbox_css()}</style>
+        <div class="gbox-info">
+        <h4>{src_class_name}</h4>
+        <div class="row">
+            <div class="column">
+                <div class="info-box">
+                    {info_html}
+                    <div>{svg_global_txt}</div>
+                </div>
+            </div>
+            <div class="column svg-zoomed">{svg_zoomed_txt}</div>
+        </div>
+        <details>
+            <summary>WKT</summary>
+            <div class="wkt">{wkt}</div>
+        </details>
+        </div>"""
+        )

--- a/tests/test_gcp.py
+++ b/tests/test_gcp.py
@@ -73,6 +73,8 @@ def test_gcp_geobox_basics(au_gcp_geobox: GCPGeoBox):
 
     assert len(set([gbox, gbox.center_pixel, gbox[:1, :2], gbox[:1, :2]])) == 3
 
+    assert len(gbox.gcps()) == 24
+
 
 def test_gcp_mapping():
     gbox0 = GeoBox.from_bbox([0, 0, 20, 10], crs="epsg:4326", resolution=1)

--- a/tests/test_gcp.py
+++ b/tests/test_gcp.py
@@ -1,0 +1,111 @@
+# pylint: disable=wrong-import-position
+from pathlib import Path
+
+import pytest
+
+from odc.geo import geom
+from odc.geo.gcp import GCPGeoBox, GCPMapping
+from odc.geo.geobox import GeoBox
+
+rasterio = pytest.importorskip("rasterio")
+
+
+@pytest.fixture()
+def au_gcp_rio(data_dir: Path):
+    with rasterio.open(data_dir / "au-gcp.tif") as src:
+        yield src
+
+
+@pytest.fixture()
+def au_gcp_geobox(au_gcp_rio):
+    yield GCPGeoBox.from_rio(au_gcp_rio)
+
+
+def test_gcp_geobox_from_rio(au_gcp_rio):
+    src = au_gcp_rio
+    assert src.gcps != ([], None)
+    gbox = GCPGeoBox.from_rio(src)
+    assert gbox.crs == "epsg:4326"
+
+    assert src.width == gbox.width
+    assert src.height == gbox.height
+
+
+def test_gcp_geobox_basics(au_gcp_geobox: GCPGeoBox):
+    gbox = au_gcp_geobox
+
+    assert gbox.linear is False
+    assert gbox.axis_aligned is False
+
+    assert gbox.pad(1)[1:-1, 1:-1] == gbox
+    assert gbox.pad(1).width == gbox.width + 2
+    assert gbox.pad(-1).height == gbox.height - 2
+
+    assert (gbox.extent - gbox.pad(2).extent).is_empty
+    assert gbox.geographic_extent.crs == "epsg:4326"
+
+    assert gbox.boundary().shape[1] == 2
+
+    assert gbox.approx.shape == gbox.shape
+    assert isinstance(gbox.approx, GeoBox)
+
+    assert gbox.resolution.xy == pytest.approx((0.308896, -0.269107), abs=1e-5)
+    assert gbox.resolution == gbox._mapping.resolution
+
+    g2 = gbox.pad_wh(10)
+    assert g2.width % 10 == 0 and g2.width >= gbox.width
+    assert g2.height % 10 == 0 and g2.height >= gbox.height
+    assert g2[0, 0] == gbox[0, 0]
+    assert str(gbox) != str(g2)
+    assert g2.resolution == gbox.resolution
+
+    assert gbox.center_pixel == gbox[gbox.height // 2, gbox.width // 2]
+
+    assert str(gbox) == repr(gbox)
+    assert gbox != "some other thing"
+
+    assert gbox.wld2pix(*gbox.pix2wld(0, 0)) == pytest.approx((0, 0), abs=1)
+    assert gbox.wld2pix(*gbox.pix2wld(133, 83)) == pytest.approx((133, 83), abs=1)
+
+    assert gbox.zoom_to(50).shape.wh == (50, 47)
+
+    assert gbox.zoom_out(0.5).zoom_out(2) == gbox
+
+    assert len(set([gbox, gbox.center_pixel, gbox[:1, :2], gbox[:1, :2]])) == 3
+
+
+def test_gcp_mapping():
+    gbox0 = GeoBox.from_bbox([0, 0, 20, 10], crs="epsg:4326", resolution=1)
+    assert gbox0.shape.wh == (20, 10)
+    assert gbox0.crs == "epsg:4326"
+
+    px, py = gbox0.boundary(4).T
+    pix = geom.multipoint([(x, y) for x, y in zip(px.tolist(), py.tolist())], None)
+
+    wx, wy = gbox0.pix2wld(px, py)
+    wld = geom.multipoint([(x, y) for x, y in zip(wx.tolist(), wy.tolist())], gbox0.crs)
+
+    mapping = GCPMapping(pix, wld)
+    assert mapping.crs == gbox0.crs
+    _pix, _wld = mapping.points()
+    assert _wld.crs == gbox0.crs
+    assert _pix.crs is None
+
+    assert (pix - _pix).is_empty
+    assert (wld - _wld).is_empty
+
+    assert mapping.approx[:6] == pytest.approx(gbox0.affine[:6], abs=1e-6)
+
+    for pt in pix.geoms:
+        # there and back with minimal loss of precision
+        _pt = pt.transform(mapping.p2w).transform(mapping.w2p)
+        assert _pt.coords[0] == pytest.approx(pt.coords[0], abs=1e-6)
+
+    for pt in wld.geoms:
+        # there and back with minimal loss of precision
+        _pt = pt.transform(mapping.w2p).transform(mapping.p2w)
+        assert _pt.coords[0] == pytest.approx(pt.coords[0], abs=1e-6)
+
+    _m2 = GCPMapping(mapping._pix, wld)
+    assert _m2.crs == mapping.crs
+    assert _m2._pix is mapping._pix

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -438,3 +438,14 @@ def test_lrtb():
 
     assert gbox.bottom == GeoBox.from_bbox([0, -10, 20, 0], gbox.crs, shape=gbox.shape)
     assert gbox.top == GeoBox.from_bbox([0, 10, 20, 20], gbox.crs, shape=gbox.shape)
+
+
+def test_compat():
+    gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))
+    gbox_ = gbox.compat
+    if gbox_ is None:  # no datacube in this environment
+        return
+    assert gbox.width == gbox_.width
+    assert gbox.height == gbox_.height
+    assert gbox.affine == gbox_.affine
+    assert gbox.crs == str(gbox.crs)

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -876,8 +876,18 @@ def test_filter():
     poly = geom.box(1, 2, 3, 4, epsg4326)
     ring = poly.exterior
     multi_pt = geom.multipoint([(1, 1), (2, 2)], epsg4326)
+    poly_with_holes = poly - poly.centroid.buffer(0.1)
+    assert len(poly_with_holes.interiors) > 0
 
-    for g in [pt, poly, ring, multi_pt, pt | ring, ring.buffer(1) | ring]:
+    for g in [
+        pt,
+        poly,
+        poly_with_holes,
+        ring,
+        multi_pt,
+        pt | ring,
+        ring.buffer(1) | ring,
+    ]:
         assert g.filter(_drop).is_empty
         assert g.filter(_keep) == g
         assert g.dropna() == g

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -372,6 +372,15 @@ def test_xr_reproject(xx_epsg4326: xr.DataArray):
     xx = xx_epsg4326.odc.reproject("epsg:3857", dst_nodata=255)
     assert xx.odc.nodata == 255
 
+    # multi-time should work just the same
+    xx2 = xx_epsg4326.expand_dims(time=2).odc.reproject("epsg:3857", dst_nodata=255)
+    assert xx2.shape[0] == 2
+    np.testing.assert_array_equal(xx2[0], xx)
+    np.testing.assert_array_equal(xx2[1], xx)
+
+    xx_i8 = xx_epsg4326.astype("int8")
+    assert xx_i8.odc.reproject("epsg:3857").dtype == "int8"
+
     # non-georegistered case
     with pytest.raises(ValueError):
         _ = xx_epsg4326[:0, :0].odc.reproject(dst_gbox)


### PR DESCRIPTION
Generalizes concept of `GeoBox` to include any bounded pixel plane with some well-defined mapping between pixel and world planes. Original `GeoBox` is a version of that with linear mapping `pix<->wld`.

This PR moves common properties of "geoboxes" into `GeoBoxBase` and adds `GCPGeoBox` class that handles ground control point based geoboxes.

- `xx.odc.geobox` will now return `GCPGeoBox` for GCP sources loaded with rioxarray
- `xr_coords|xr_zeros` can create xarrays from `GCPGeoBox`
- `xr_reproject` accepts GCP registered arrays as sources, but not as destinations as this is not exposed in rasterio
- `xx.odc.add_to(map)` also works for GCP based sources
- overlap computation logic has been updated to work either geobox type
- moved GeoBox html_repr logic into a separate class and file to enable sharing with GCPGeoBox


Other coincidental changes

- `Geometry` can now be constructed from geojson
- Adding more tests
- Fix `.dropna` for polygons with holes


