### PR TITLE
Add CRS.utm and support crs="utm" inputs in to_crs methods

### DIFF
--- a/docs/api-geobox.rst
+++ b/docs/api-geobox.rst
@@ -37,6 +37,7 @@ GeoBox
    GeoBox.shape
    GeoBox.transform
    GeoBox.translate_pix
+   GeoBox.snap_to
    GeoBox.to_crs
    GeoBox.width
    GeoBox.zoom_out

--- a/docs/api-geobox.rst
+++ b/docs/api-geobox.rst
@@ -38,6 +38,7 @@ GeoBox
    GeoBox.transform
    GeoBox.translate_pix
    GeoBox.snap_to
+   GeoBox.enclosing
    GeoBox.to_crs
    GeoBox.width
    GeoBox.zoom_out

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -69,6 +69,7 @@ Contains CRS class and related operations.
    :toctree: _api/
 
    CRS
+   CRS.utm
    CRS.to_epsg
    CRS.to_wkt
    CRS.transformer_to_crs

--- a/odc/geo/_version.py
+++ b/odc/geo/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.2.2"
+__version__ = "0.3.0rc0"

--- a/odc/geo/crs.py
+++ b/odc/geo/crs.py
@@ -357,25 +357,35 @@ class CRSMismatchError(ValueError):
 @overload
 def norm_crs(crs: SomeCRS) -> CRS: ...
 @overload
+def norm_crs(crs: SomeCRS, ctx: Any) -> CRS: ...
+@overload
 def norm_crs(crs: None) -> None: ...
+@overload
+def norm_crs(crs: None, ctx: Any) -> None: ...
 # fmt: on
 
 
-def norm_crs(crs: MaybeCRS) -> Optional[CRS]:
+def norm_crs(crs: MaybeCRS, ctx=None) -> Optional[CRS]:
     """Normalise CRS representation."""
     if isinstance(crs, CRS):
         return crs
     if crs is None:
         return None
+    if isinstance(crs, str) and crs.lower() == "utm":
+        assert ctx is not None
+        return CRS.utm(ctx)
     return CRS(crs)
 
 
-def norm_crs_or_error(crs: MaybeCRS) -> CRS:
+def norm_crs_or_error(crs: MaybeCRS, ctx=None) -> CRS:
     """Normalise CRS representation, raise error if input is ``None``."""
     if isinstance(crs, CRS):
         return crs
     if crs is None:
         raise ValueError("Expect valid CRS")
+    if isinstance(crs, str) and crs.lower() == "utm":
+        assert ctx is not None
+        return CRS.utm(ctx)
     return CRS(crs)
 
 

--- a/odc/geo/crs.py
+++ b/odc/geo/crs.py
@@ -50,8 +50,8 @@ def _make_crs_transform_key(from_crs, to_crs, always_xy):
 
 
 @cachetools.cached({}, key=_make_crs_transform_key)
-def _make_crs_transform(from_crs, to_crs, always_xy):
-    return Transformer.from_crs(from_crs, to_crs, always_xy=always_xy).transform
+def _make_crs_transform(from_crs: _CRS, to_crs: _CRS, always_xy: bool) -> Transformer:
+    return Transformer.from_crs(from_crs, to_crs, always_xy=always_xy)
 
 
 class CRS:
@@ -293,10 +293,10 @@ class CRS:
         """
 
         # pylint: disable=protected-access
-        transform = _make_crs_transform(self._crs, other._crs, always_xy=always_xy)
+        tr = _make_crs_transform(self._crs, other._crs, always_xy=always_xy)
 
-        def result(x, y):
-            rx, ry = transform(x, y)  # pylint: disable=unpacking-non-sequence
+        def result(x, y, **kw):
+            rx, ry = tr.transform(x, y, **kw)  # pylint: disable=unpacking-non-sequence
 
             if not isinstance(rx, numpy.ndarray) or not isinstance(ry, numpy.ndarray):
                 return (rx, ry)

--- a/odc/geo/gcp.py
+++ b/odc/geo/gcp.py
@@ -210,7 +210,7 @@ class GCPGeoBox(GeoBoxBase):
         if not self._affine.is_identity:
             pix = pix.transform(~self._affine)
         wld = wld.to_crs(crs)
-        mapping = GCPMapping(pix, wld, crs)
+        mapping = GCPMapping(pix, wld, wld.crs)
         return GCPGeoBox(self._shape, mapping)
 
     def pad(self, padx: int, pady: MaybeInt = None) -> "GCPGeoBox":

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -363,10 +363,19 @@ class GeoBox(GeoBoxBase):
         elif anchor == AnchorEnum.CENTER:
             _snap = xy_(0.5, 0.5)
 
+        def _norm_bbox(
+            bbox: Tuple[float, float, float, float], crs: MaybeCRS
+        ) -> BoundingBox:
+            if isinstance(crs, str):
+                if crs.lower() == "utm":
+                    return BoundingBox(*bbox, crs="epsg:4326").to_crs("utm")
+
+            return BoundingBox(*bbox, crs=(crs or "epsg:4326"))
+
         if not isinstance(bbox, BoundingBox):
-            bbox = BoundingBox(*bbox, crs=(crs or "epsg:4326"))
+            bbox = _norm_bbox(bbox, crs)
         elif bbox.crs is None:
-            bbox = BoundingBox(*bbox.bbox, crs=(crs or "epsg:4326"))
+            bbox = _norm_bbox(bbox.bbox, crs)
 
         if isinstance(shape, (int, float)):
             if bbox.aspect > 1:

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -265,6 +265,21 @@ class GeoBoxBase:
         return self._ui._repr_html_()
 
     def compute_crop(self, roi) -> Tuple[Shape2d, Affine]:
+        if isinstance(roi, BoundingBox):
+            roi = roi.polygon
+        if isinstance(roi, GeoBoxBase):
+            roi = roi.extent
+
+        if isinstance(roi, Geometry):
+            if roi.crs is not None:
+                roi = self.project(roi)
+            pix_bbox = roi.boundingbox.round() & BoundingBox(
+                0, 0, self.width, self.height
+            )
+            nx, ny = (max(1, int(span)) for span in (pix_bbox.span_x, pix_bbox.span_y))
+            tx, ty = map(int, pix_bbox.bbox[:2])
+            roi = numpy.s_[ty : ty + ny, tx : tx + nx]
+
         if isinstance(roi, int):
             roi = (slice(roi, roi + 1), slice(None, None))
 

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -375,8 +375,8 @@ class GeoBox(GeoBoxBase):
             bbox: Tuple[float, float, float, float], crs: MaybeCRS
         ) -> BoundingBox:
             if isinstance(crs, str):
-                if crs.lower() == "utm":
-                    return BoundingBox(*bbox, crs="epsg:4326").to_crs("utm")
+                if crs.lower().startswith("utm"):
+                    return BoundingBox(*bbox, crs="epsg:4326").to_crs(crs)
 
             return BoundingBox(*bbox, crs=(crs or "epsg:4326"))
 

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -310,6 +310,26 @@ class GeoBoxBase:
         A = self._affine * Affine.scale(sx, sy)
         return (shape, A)
 
+    def project(self, g: Geometry) -> Geometry:
+        """
+        Map Geometry between world and pixel coords.
+
+        When input geometry has no CRS, map from pixels to the world.
+
+        When input geometry has CRS (can be different from GeoBox), project
+        geometry into pixel coordinates, note that result is not clipped to the
+        image bounds.
+        """
+        if g.crs is None:  # assume pixel plane
+            g = g.transform(self.pix2wld)
+            return Geometry(g.geom, self._crs)
+
+        assert self._crs is not None
+        if g.crs != self._crs:
+            g = g.to_crs(self._crs)
+        g = g.transform(self.wld2pix)
+        return Geometry(g.geom, crs=None)
+
 
 class GeoBox(GeoBoxBase):
     """

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -23,6 +23,7 @@ from typing import (
 
 import numpy
 from affine import Affine
+from pyproj.aoi import AreaOfInterest
 from shapely import geometry, ops
 from shapely.geometry import base
 
@@ -239,6 +240,15 @@ class BoundingBox(Sequence[float]):
         p1 = transform * (0, 0)
         p2 = transform * shape_(shape).xy
         return BoundingBox.from_points(p1, p2, crs=crs)
+
+    @property
+    def aoi(self) -> AreaOfInterest:
+        """
+        Interop with pyproj.
+        """
+        if self._crs is None or self._crs == "epsg:4326":
+            return AreaOfInterest(*self._box)
+        return AreaOfInterest(*self.to_crs("epsg:4326").bbox)
 
 
 def wrap_shapely(method):

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -558,7 +558,7 @@ class Geometry(SupportsCoords[float]):
            geographic projections. Currently only works in few specific cases (source CRS is smooth
            over the dateline).
         """
-        crs = norm_crs_or_error(crs)
+        crs = norm_crs_or_error(crs, self)
         if self.crs == crs:
             return self
 
@@ -785,7 +785,7 @@ def projected_lon(
     :param lat: Optionally limit range of the line
     :param step: Line "resolution" in degrees
     """
-    crs = norm_crs_or_error(crs)
+    crs = norm_crs_or_error(crs, lon)
     yy = numpy.arange(lat[0], lat[1], step, dtype="float32")
     xx = numpy.full_like(yy, lon)
     tr = CRS("EPSG:4326").transformer_to_crs(crs)

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -250,6 +250,15 @@ class BoundingBox(Sequence[float]):
             return AreaOfInterest(*self._box)
         return AreaOfInterest(*self.to_crs("epsg:4326").bbox)
 
+    def round(self) -> "BoundingBox":
+        """
+        Expand bounding box to nearest integer on all sides.
+        """
+        x0, y0, x1, y1 = self._box
+        return BoundingBox(
+            math.floor(x0), math.floor(y0), math.ceil(x1), math.ceil(y1), crs=self._crs
+        )
+
 
 def wrap_shapely(method):
     """

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -98,6 +98,12 @@ class BoundingBox(Sequence[float]):
     def __str__(self) -> str:
         return self.__repr__()
 
+    def __and__(self, other: "BoundingBox") -> "BoundingBox":
+        return bbox_intersection([self, other])
+
+    def __or__(self, other: "BoundingBox") -> "BoundingBox":
+        return bbox_union([self, other])
+
     def buffered(self, xbuff: float, ybuff: Optional[float] = None) -> "BoundingBox":
         """
         Return a new BoundingBox, buffered in the x and y dimensions.

--- a/odc/geo/math.py
+++ b/odc/geo/math.py
@@ -365,7 +365,7 @@ def decompose_rws(A: AffineX) -> Tuple[AffineX, AffineX, AffineX]:
        * ``(R*(-I))*((-I)*S) == R*S``
 
 
-     :return: Rotation, Sheer, Scale ``2x2`` matrices
+     :return: Rotation, Shear, Scale ``2x2`` matrices
     """
     # pylint: disable=too-many-locals
 

--- a/odc/geo/overlap.py
+++ b/odc/geo/overlap.py
@@ -9,7 +9,7 @@ from typing import Literal, Optional, Protocol, Sequence, Tuple, Union
 import numpy as np
 from affine import Affine
 
-from .crs import SomeCRS, norm_crs
+from .crs import SomeCRS
 from .gcp import GCPGeoBox
 from .geobox import GeoBox, GeoBoxBase, gbox_boundary
 from .math import (
@@ -587,12 +587,12 @@ def compute_output_geobox(
        projection.
     """
     # pylint: disable=too-many-locals
-
-    dst_crs = norm_crs(crs)
     src_crs = gbox.crs
     assert src_crs is not None
 
-    bbox = gbox.footprint(dst_crs, buffer=0.9, npoints=100).boundingbox
+    bbox = gbox.footprint(crs, buffer=0.9, npoints=100).boundingbox
+    dst_crs = bbox.crs
+    assert dst_crs is not None
     same_units = src_crs.units == dst_crs.units
 
     if resolution == "same":

--- a/odc/geo/ui.py
+++ b/odc/geo/ui.py
@@ -288,7 +288,7 @@ class PixelGridDisplay:
                 ]
             )
         if mode == "pixel":
-            return pix
+            return geom.Geometry(pix.geom, crs=None)
 
         native = pix.transform(self._pix2world)
         if mode == "native":

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1,5 +1,6 @@
 import pytest
 from affine import Affine
+from pyproj.aoi import AreaOfInterest
 
 from odc.geo import BoundingBox, wh_
 from odc.geo.geom import bbox_intersection, bbox_union
@@ -17,6 +18,7 @@ def test_boundingbox():
     assert bb.bbox == (0, 3, 2, 4)
     assert "crs=" not in str(bb)
     assert "crs=" not in repr(bb)
+    assert bb.aoi == AreaOfInterest(0, 3, 2, 4)
 
     bb = BoundingBox(0, 3, 2.1, 4, "epsg:4326")
     assert bb.width == 2
@@ -27,6 +29,7 @@ def test_boundingbox():
     assert bb.crs.epsg == 4326
     assert "crs=" in str(bb)
     assert "crs=" in repr(bb)
+    assert bb.aoi == AreaOfInterest(0, 3, 2.1, 4)
 
     assert BoundingBox.from_xy(bb.range_x, bb.range_y, bb.crs) == bb
 
@@ -49,6 +52,10 @@ def test_boundingbox():
     )
 
     assert bb.polygon.boundingbox == bb
+
+    bb = BoundingBox(0, 3, 2, 4, "epsg:3857")
+    assert bb.aoi == bb.to_crs("epsg:4326").aoi
+    assert bb.aoi != AreaOfInterest(0, 3, 2, 4)
 
 
 @pytest.mark.parametrize("crs", [None, "epsg:4326", epsg3857])

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -72,6 +72,22 @@ def test_bbox_union(crs):
     bb = bbox_union(iter([b2, b1] * 10))
     assert bb == BoundingBox(0, 1, 11, 22, crs)
 
+    assert b2 | b1 == bbox_union([b2, b1])
+    assert b1 | b2 == bbox_union([b2, b1])
+
+
+@pytest.mark.parametrize("crs", [None, "epsg:4326", epsg3857])
+def test_bbox_intersection(crs):
+    b1 = BoundingBox(0, 1, 10, 20, crs)
+    b2 = BoundingBox(3, -10, 12, 8, crs)
+
+    assert b1 & b2 == bbox_intersection([b1, b2])
+    assert b2 & b1 == bbox_intersection([b1, b2])
+    assert b1 & b1 == b1
+    assert b2 & b2 == b2
+    assert bbox_intersection([b1, b2]) == BoundingBox(3, 1, 10, 8, crs)
+    assert b1 & b2 == BoundingBox(3, 1, 10, 8, crs)
+
 
 @pytest.mark.parametrize(
     "crss",

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -103,3 +103,22 @@ def test_map_bounds():
 def test_bbox_to_crs():
     bbox = BoundingBox(-10, -20, 100, 0, "epsg:4326")
     assert bbox.to_crs("epsg:3857") == bbox.polygon.to_crs("epsg:3857").boundingbox
+
+
+@pytest.mark.parametrize(
+    "bb,expect",
+    [
+        ((-10, -20, 100, 0), (-10, -20, 100, 0)),
+        ((-10.1, 2.3, 10.9, 2.4), (-11, 2, 11, 3)),
+        ((-10.9, 2.6, 10.9, 2.9), (-11, 2, 11, 3)),
+        ((0.9, 1.9, 1.01, 5.02), (0, 1, 2, 6)),
+    ],
+)
+@pytest.mark.parametrize("crs", ["epsg:4326", None, "epsg:3857"])
+def test_round(bb, expect, crs):
+    expect = BoundingBox(*expect, crs)
+    bbox = BoundingBox(*bb, crs)
+
+    assert bbox.round().round() == bbox.round()
+    assert bbox.round().polygon.contains(bbox.polygon)
+    assert expect == bbox.round()

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -11,7 +11,14 @@ import rasterio.crs
 from pytest import approx
 
 from odc.geo import geom
-from odc.geo.crs import CRS, CRSError, CRSMismatchError, crs_units_per_degree
+from odc.geo.crs import (
+    CRS,
+    CRSError,
+    CRSMismatchError,
+    crs_units_per_degree,
+    norm_crs,
+    norm_crs_or_error,
+)
 from odc.geo.geom import common_crs
 from odc.geo.testutils import epsg3577, epsg3857, epsg4326
 from odc.geo.types import xy_
@@ -244,3 +251,7 @@ def test_crs_utm(x, expected_epsg):
 
     assert crs.epsg is not None
     assert crs.epsg == expected_epsg
+    if not isinstance(x, tuple):
+        assert norm_crs_or_error("utm", x).epsg == expected_epsg
+        assert norm_crs_or_error("UTM", x).epsg == expected_epsg
+        assert norm_crs("UTM", x).epsg == expected_epsg

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -241,6 +241,9 @@ def test_rio_crs__no_epsg():
         (geom.point(6.89, 50.3, None), 32632),
         (geom.point(6.89, 50.3, "epsg:4326").to_crs("epsg:3857"), 32632),
         (geom.point(6.89, 50.3, "epsg:4326").to_crs("epsg:3857").buffer(1000), 32632),
+        (geom.BoundingBox(0, 10, 7, 20), 32631),
+        (geom.BoundingBox(0, 10, 7, 20, "epsg:4326"), 32631),
+        (geom.BoundingBox(5, 10, 8, 20), 32632),
     ],
 )
 def test_crs_utm(x, expected_epsg):
@@ -255,3 +258,6 @@ def test_crs_utm(x, expected_epsg):
         assert norm_crs_or_error("utm", x).epsg == expected_epsg
         assert norm_crs_or_error("UTM", x).epsg == expected_epsg
         assert norm_crs("UTM", x).epsg == expected_epsg
+
+        with pytest.raises(ValueError):
+            _ = CRS.utm(x, datum_name="no such datum")

--- a/tests/test_gcp.py
+++ b/tests/test_gcp.py
@@ -83,6 +83,13 @@ def test_gcp_geobox_basics(au_gcp_geobox: GCPGeoBox):
     assert gbox_.wld2pix(*gbox_.pix2wld(0, 0)) == pytest.approx((0, 0), abs=1)
     assert gbox_.wld2pix(*gbox_.pix2wld(133, 83)) == pytest.approx((133, 83), abs=1)
 
+    gbox_ = gbox.to_crs("utm")
+    assert gbox_.shape == gbox.shape
+    assert gbox_.crs is not None
+    assert gbox_.crs.proj.utm_zone is not None
+    assert gbox_.wld2pix(*gbox_.pix2wld(0, 0)) == pytest.approx((0, 0), abs=1)
+    assert gbox_.wld2pix(*gbox_.pix2wld(133, 83)) == pytest.approx((133, 83), abs=1)
+
     assert gbox.pad(2).to_crs("epsg:6933").crs == "epsg:6933"
 
     p1, p2 = gbox.map_bounds()
@@ -119,7 +126,7 @@ def test_gcp_geobox_xr(au_gcp_geobox: GCPGeoBox):
     # corrupt some gcps
     yy.spatial_ref.attrs["gcps"]["features"][0].pop("properties")
     # should not throw, just return None
-    yy.odc.uncached.geobox is None
+    assert yy.odc.uncached.geobox is None
 
 
 def test_gcp_reproject(au_gcp_geobox: GCPGeoBox):

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -402,6 +402,28 @@ def test_to_crs():
     assert gbox.to_crs("epsg:4326").extent.contains(gbox.geographic_extent)
 
 
+def test_snap_to():
+    def aligned(a, b):
+        try:
+            _ = a & b
+        except ValueError:
+            return False
+        return True
+
+    gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))
+    assert aligned(gbox, gbox[2:, 3:])
+    assert gbox.snap_to(gbox[2:, 3:]) == gbox
+
+    gbox_ = gbox.center_pixel.translate_pix(0.1, 0.2).pad(10)
+    assert not aligned(gbox, gbox_)
+    assert aligned(gbox, gbox_.snap_to(gbox))
+    assert aligned(gbox.snap_to(gbox_), gbox_)
+
+    assert gbox.snap_to(gbox_) != gbox
+    assert gbox.snap_to(gbox_).shape == gbox.shape
+    assert gbox.snap_to(gbox_).crs == gbox.crs
+
+
 def test_svg():
     # smoke test only
     gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -385,6 +385,7 @@ def test_outline():
     assert gbox.outline().crs == gbox.crs
     assert gbox.outline("geo").crs == "epsg:4326"
     assert gbox.outline("pixel").boundingbox == (0, 0, 200, 100)
+    assert gbox.outline("pixel").crs is None
     assert gbox.outline(notch=0).type == "GeometryCollection"
 
 

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -500,3 +500,19 @@ def test_compat():
     assert gbox.height == gbox_.height
     assert gbox.affine == gbox_.affine
     assert gbox.crs == str(gbox.crs)
+
+
+def test_project():
+    gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))
+
+    pix = gbox.outline("pixel", notch=0)
+    assert pix.crs is None
+    wld = gbox.project(pix)
+    assert wld.crs == gbox.crs
+    assert wld == gbox.outline("native", notch=0)
+
+    assert gbox.project(wld).crs is None
+    assert gbox.project(wld.to_crs("epsg:4326")).crs is None
+
+    assert gbox.project(wld).buffer(0.001).contains(pix)
+    assert gbox.project(wld.to_crs("epsg:4326")).buffer(0.001).contains(pix)

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -207,6 +207,14 @@ def test_geobox():
     assert gbox[0, 0:1] == gbox[:1, :1]
     assert gbox[0:1, 1] == gbox[:1, 1:2]
 
+    assert gbox[gbox.extent] == gbox
+    assert gbox[gbox.geographic_extent] == gbox
+    assert gbox[gbox] == gbox
+    assert gbox[gbox[3:6, :4].extent.boundingbox] == gbox[3:6, :4]
+    assert gbox[gbox.extent.centroid].shape.wh == (1, 1)
+    assert gbox[geom.point(0.5, 0.5, None)] == gbox[:1, :1]
+    assert gbox[geom.point(0, 0.9, None)] == gbox[:1, :1]
+
     with pytest.raises(NotImplementedError):
         gbox[::2, :]
 

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -392,6 +392,7 @@ def test_footprint():
     gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))
     assert gbox.footprint("epsg:4326").crs == "epsg:4326"
     assert gbox.footprint("utm").crs.proj.utm_zone is not None
+    assert gbox.footprint("utm-s").crs.proj.utm_zone.endswith("S")
 
 
 def test_to_crs():
@@ -400,6 +401,12 @@ def test_to_crs():
     assert gbox.to_crs("utm") == gbox.to_crs("epsg:32631")
     assert gbox.to_crs("utm").extent.contains(gbox.extent.to_crs("epsg:32631"))
     assert gbox.to_crs("epsg:4326").extent.contains(gbox.geographic_extent)
+    assert gbox.to_crs("utm-n") == gbox.to_crs("utm")
+    assert gbox.to_crs("utm-s").crs.proj.utm_zone == "31S"
+
+    gbox = GeoBox.from_bbox([0, -50, 20, -10], "epsg:3857", shape=wh_(200, 100))
+    assert gbox.to_crs("utm").crs.proj.utm_zone == "31S"
+    assert gbox.to_crs("utm-n").crs.proj.utm_zone == "31N"
 
 
 def test_snap_to():

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -363,6 +363,12 @@ def test_to_crs():
         poly.to_crs(epsg3857)
 
 
+def test_to_crs_utm():
+    poly = geom.box(0.1, 43, 1.3, 44, epsg4326)
+    assert poly.to_crs("utm").crs.epsg == 32631
+    assert poly.to_crs("utm") == poly.to_crs(32631)
+
+
 def test_densify():
     s_x10 = [(0, 0), (10, 0)]
     assert densify(s_x10, 20) == s_x10

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -367,6 +367,11 @@ def test_to_crs_utm():
     poly = geom.box(0.1, 43, 1.3, 44, epsg4326)
     assert poly.to_crs("utm").crs.epsg == 32631
     assert poly.to_crs("utm") == poly.to_crs(32631)
+    assert poly.to_crs("utm-s").crs.epsg == 32731
+
+    poly = geom.box(0.1, -44, 1.3, -43, epsg4326)
+    assert poly.to_crs("utm-n").crs.epsg == 32631
+    assert poly.to_crs("utm") == poly.to_crs(32731)
 
 
 def test_densify():

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -156,6 +156,7 @@ def test_odc_extension(xx_epsg4326: xr.DataArray, geobox_epsg4326: GeoBox):
     assert xx.odc.uncached.transform == xx.odc.transform
     assert xx.odc.output_geobox("epsg:3857").crs == "epsg:3857"
     assert xx.odc.map_bounds() == gbox.map_bounds()
+    assert xx.odc.output_geobox("utm").crs.epsg is not None
 
     # this drops encoding/attributes, but crs/geobox should remain the same
     _xx = xx * 10.0


### PR DESCRIPTION
## UTM convenience methods

1. `CRS.utm(some_geom)` picks appropriate utm zone for a given geometry and returns corresponding CRS object
2. When transforming geometry or geobox accept `crs="utm|utm-n|utm-s"` as a valid destination crs, meaning pick "appropriate" utm CRS for an object being transformed.
3. ~"appropriate UTM zone" is currently defined by the `lon,lat` of the centroid of the geometry~
4. UTM zones that overlap with `some_geom` are located using `pyproj`, then zone with biggest overlap is chosen


## Snap to

Adds `GeoBox.snap_to(other)`, this method adjust source geobox slightly by shifting footprint by a sub-pixel amount such that pixel edges align exactly with pixel edges of the `other` geobox. Method returns adjusted copy of self. Method only works when it is possible to align pixels by pure translation only - same projection, same resolution, same orientation. `ValueError` is raised when it's not possible.

Closes #59

## Enclosing

Related to `snap_to` somewhat. GeoBox construction method that creates a new "pixel grid compatible" geobox that minimally covers some area.

## Generalized Slicing into GeoBox

Overload `geobox[roi]` to support geometry types on input, footprint in the world can be converted to pixel space, from which pixel slice is computed.

Closes #31