### PR TITLE
Support GCPGeoBoxes with few points only

### DIFF
--- a/docs/api-geobox.rst
+++ b/docs/api-geobox.rst
@@ -43,6 +43,7 @@ GeoBox
    GeoBox.width
    GeoBox.zoom_out
    GeoBox.zoom_to
+   GeoBox.qr2sample
    GeoBox.__mul__
    GeoBox.__rmul__
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -104,6 +104,7 @@ Shapely geometry classes with CRS information attached.
    BoundingBox.transform
    BoundingBox.buffered
    BoundingBox.boundary
+   BoundingBox.qr2sample
 
    box
    line
@@ -224,6 +225,8 @@ odc.geo.math
    snap_affine
    split_float
    split_translation
+
+   quasi_random_r2
 
 odc.geo.gridspec
 ****************

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -130,6 +130,7 @@ Shapely geometry classes with CRS information attached.
    bbox_union
    unary_intersection
    unary_union
+   triangulate
 
 odc.geo
 *******

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -103,7 +103,7 @@ Shapely geometry classes with CRS information attached.
    BoundingBox.from_transform
    BoundingBox.transform
    BoundingBox.buffered
-
+   BoundingBox.boundary
 
    box
    line
@@ -203,16 +203,23 @@ odc.geo.math
    Bin1D.bin
    Bin1D.from_sample_bin
 
+   Poly2d
+   Poly2d.fit
+   Poly2d.grid2d
+   Poly2d.with_input_transform
+
    affine_from_axis
    align_down
    align_up
    apply_affine
    clamp
    data_resolution_and_offset
+   edge_index
    is_affine_st
    is_almost_int
    maybe_int
    maybe_zero
+   norm_xy
    snap_scale
    snap_affine
    split_float

--- a/odc/geo/_version.py
+++ b/odc/geo/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.0rc0"
+__version__ = "0.3.0rc1"

--- a/odc/geo/converters.py
+++ b/odc/geo/converters.py
@@ -3,9 +3,11 @@ Interop with other geometry libraries.
 """
 
 import re
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Union
 
 from .crs import CRS, MaybeCRS, Optional, norm_crs
+from .gcp import GCPGeoBox
+from .geobox import GeoBox
 from .geom import Geometry, point
 from .types import XY, xy_
 
@@ -46,7 +48,7 @@ def extract_gcps(
     """
     Extract Ground Control points from :py:class:`rasterio.DatasetReader`.
 
-    :returns: ``[pixel coors], [world coords]``
+    :returns: ``[pixel coords], [world coords]``
     """
     pix, wld, gcp_crs = extract_gcps_raw(src)
     output_crs = norm_crs(output_crs)
@@ -78,3 +80,18 @@ def map_crs(m: Any, /) -> Optional[CRS]:
             return CRS(proj4def)
 
     return None
+
+
+def rio_geobox(rdr: Any) -> Union[GeoBox, GCPGeoBox]:
+    """
+    Construct GeoBox from rasterio.
+
+    :param rdr: Opened :py:class:`rasterio.DatasetReader`
+    :returns:
+       :py:class:`~odc.geo.geobox.GeoBox` or :py:class:`~odc.geo.gcp.GCPGeoBox`.
+    """
+    pts, _ = rdr.gcps
+    if len(pts) > 0:
+        return GCPGeoBox.from_rio(rdr)
+
+    return GeoBox.from_rio(rdr)

--- a/odc/geo/data/__init__.py
+++ b/odc/geo/data/__init__.py
@@ -4,7 +4,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-from ..geom import Geometry, MaybeCRS, box, multigeom
+from ..crs import MaybeCRS, norm_crs
+from ..geom import Geometry, box, multigeom
 
 
 def data_path(fname: Optional[str] = None) -> Path:
@@ -29,6 +30,7 @@ def ocean_geom(
     gg = multigeom([Geometry(f["geometry"], "epsg:4326") for f in gjson["features"]])
     if bbox is not None:
         gg = gg & box(*bbox, "epsg:4326")
+    crs = norm_crs(crs)
     if crs is not None:
         gg = gg.to_crs(crs)
 
@@ -52,6 +54,7 @@ def country_geom(iso3: str, crs: MaybeCRS = None) -> Geometry:
 
     df = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
     (gg,) = from_geopandas(df[df.iso_a3 == iso3])
+    crs = norm_crs(crs)
     if crs is not None:
         gg = gg.to_crs(crs)
     return gg

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -25,7 +25,7 @@ from .math import (
     split_translation,
 )
 from .roi import Tiles as RoiTiles
-from .roi import align_up, polygon_path, roi_normalise, roi_shape
+from .roi import align_up, roi_boundary, roi_normalise, roi_shape
 from .types import (
     XY,
     Index2d,
@@ -37,6 +37,7 @@ from .types import (
     SomeIndex2d,
     SomeResolution,
     SomeShape,
+    Unset,
     iyx_,
     res_,
     shape_,
@@ -141,10 +142,7 @@ class GeoBoxBase:
           in pixel coordinates.
         """
         ny, nx = self._shape.yx
-        xx = numpy.linspace(0, nx, pts_per_side, dtype="float32")
-        yy = numpy.linspace(0, ny, pts_per_side, dtype="float32")
-
-        return polygon_path(xx, yy).T[:-1]
+        return roi_boundary(numpy.s_[0:ny, 0:nx], pts_per_side)
 
     @property
     def alignment(self) -> XY[float]:

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -546,6 +546,17 @@ class GeoBox(GeoBoxBase):
             tight=tight,
         )
 
+    @staticmethod
+    def from_rio(rdr) -> "GeoBox":
+        """
+        Construct GeoBox from rasterio.
+
+        :param rdr: Openned :py:class:`rasterio.DatasetReader`
+        :returns:
+           :py:class:`~odc.geo.geobox.GeoBox`
+        """
+        return GeoBox(rdr.shape, rdr.transform, rdr.crs)
+
     def buffered(self, xbuff: float, ybuff: Optional[float] = None) -> "GeoBox":
         """
         Produce a tile buffered by ``xbuff, ybuff`` (in CRS units).

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -343,6 +343,35 @@ class GeoBoxBase:
         g = g.transform(self.wld2pix)
         return Geometry(g.geom, crs=None)
 
+    def qr2sample(
+        self,
+        n: int,
+        padding: Optional[float] = None,
+        with_edges: bool = False,
+        offset: int = 0,
+    ) -> Geometry:
+        """
+        Generate quasi-random sample of image locations.
+
+        :param n:
+           Number of points
+
+        :param padding:
+           In pixels, minimal distance from the edge
+
+        :param offset:
+           Offset into quasi-random sequence from where to start
+
+        :param edges:
+           Also include samples along the edge and corners
+
+        References: http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+        """
+        nx, ny = self._shape.xy
+        return BoundingBox(0, 0, nx, ny, None).qr2sample(
+            n, padding=padding, with_edges=with_edges, offset=offset
+        )
+
 
 class GeoBox(GeoBoxBase):
     """

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -504,7 +504,7 @@ class GeoBox(GeoBoxBase):
                 resolution = res_(resolution)
                 anchor = xy_(ax / abs(resolution.x), ay / abs(resolution.y))
 
-        if crs is None:
+        if crs is None or isinstance(crs, Unset):
             crs = geopolygon.crs
         else:
             geopolygon = geopolygon.to_crs(crs)

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -713,7 +713,28 @@ class Geometry(SupportsCoords[float]):
 
         :return: GeoJSON Feature dictionary
         """
-        gg = self.to_crs("epsg:4326", resolution=resolution, wrapdateline=wrapdateline)
+        if self.type == "GeometryCollection":
+            return {
+                "type": "FeatureCollection",
+                "features": [
+                    g.geojson(
+                        properties=properties,
+                        simplify=simplify,
+                        resolution=resolution,
+                        wrapdateline=wrapdateline,
+                        **props,
+                    )
+                    for g in self.geoms
+                ],
+            }
+
+        if self.crs is not None:
+            gg = self.to_crs(
+                "epsg:4326", resolution=resolution, wrapdateline=wrapdateline
+            )
+        else:
+            gg = self
+
         if simplify > 0:
             gg = gg.simplify(simplify)
         if properties is None:

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -1132,6 +1132,27 @@ def unary_intersection(geoms: Iterable[Geometry]) -> Geometry:
     return functools.reduce(Geometry.intersection, geoms)
 
 
+def triangulate(pts: Geometry, **kw) -> Geometry:
+    """
+     Creates the Delaunay triangulation and returns a geometry collection.
+
+     The source may be any geometry type. All vertices of the geometry will be
+     used as the points of the triangulation.
+
+    :param tolerance:
+        From the GEOS documentation:
+        tolerance is the snapping tolerance used to improve the robustness of
+        the triangulation computation. A tolerance of 0.0 specifies that no
+        snapping will take place.
+
+     :param edges:
+        If edges is False, a geometry collection of Polygons (triangles) will be returned (default).
+        Otherwise LineString edges are returned.
+    """
+    geom = geometry.GeometryCollection(ops.triangulate(pts.geom, **kw))
+    return Geometry(geom, pts.crs)
+
+
 def intersects(a: Geometry, b: Geometry) -> bool:
     """
     Check for intersection.

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -265,6 +265,21 @@ class BoundingBox(Sequence[float]):
             math.floor(x0), math.floor(y0), math.ceil(x1), math.ceil(y1), crs=self._crs
         )
 
+    def boundary(self, pts_per_side: int = 2) -> "Geometry":
+        """
+        Points along the perimeter as a linear ring.
+        """
+        x0, y0, x1, y1 = self._box
+        xx = numpy.linspace(x0, x1, pts_per_side, dtype="float32")
+        yy = numpy.linspace(y0, y1, pts_per_side, dtype="float32")
+        return line(
+            [
+                (float(xx[ix]), float(yy[iy]))
+                for iy, ix in edge_index((pts_per_side, pts_per_side), closed=True)
+            ],
+            self.crs,
+        )
+
 
 def wrap_shapely(method):
     """

--- a/odc/geo/math.py
+++ b/odc/geo/math.py
@@ -8,13 +8,23 @@ Various mathy helpers.
 Minimal dependencies in this module.
 """
 from math import ceil, floor, fmod, isfinite
-from typing import Any, List, Literal, Optional, Sequence, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 from affine import Affine
 from numpy.polynomial.polynomial import polygrid2d, polyval2d
 
-from .types import XY, Resolution, SomeResolution, res_, resxy_, xy_
+from .types import XY, Resolution, SomeResolution, SomeShape, res_, resxy_, shape_, xy_
 
 AffineX = TypeVar("AffineX", np.ndarray, Affine)
 
@@ -499,6 +509,37 @@ def edge_index(shape: SomeShape, closed: bool = False) -> Iterator[Tuple[int, in
         yield (iy, ix)
     if closed:
         yield (0, 0)
+
+
+def quasi_random_r2(
+    n: int,
+    shape: Optional[SomeShape] = None,
+    offset: int = 0,
+) -> np.ndarray:
+    """
+    Generate quasi-random set of points.
+
+    Returns quasi-random points in ``[0, 1)`` range. If ``shape=(ny, nx)`` is
+    supplied, points are scaled to ``[0, nx), [0, ny)`` range.
+
+    :param n: Number of points to generate
+    :param offset: Generate from that offset in the sequence
+    :returns: ``nx2`` numpy array
+
+    References: http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+    """
+    idx = np.arange(offset, offset + n, dtype="float32")
+    aa = (0.7548776662466927, 0.5698402909980532)
+    xy = np.fmod(np.outer(idx, aa), 1)
+
+    if shape is not None:
+        nx, ny = shape_(shape).wh
+        xy[:, 0] *= nx
+        xy[:, 1] *= ny
+
+    return xy
+
+
 class Bin1D:
     """
     Class for translating continous coordinates to bin index.

--- a/odc/geo/math.py
+++ b/odc/geo/math.py
@@ -470,6 +470,35 @@ def resolution_from_affine(A: Affine) -> Resolution:
     return resxy_(rx, ry)
 
 
+def edge_index(shape: SomeShape, closed: bool = False) -> Iterator[Tuple[int, int]]:
+    """
+    Like ``ndindex`` in numpy but for edge locations and limited to 2d.
+
+    Returns a sequence of indexes along the edge of a 2d array of a given shape.
+    Order is fixed, starting from ``(0, 0), (0, 1)...``. See example below
+
+    .. code-block::
+
+       # for shape=(10, 8)
+       (0, 0), (0, 1) ... (0, 7),
+       (1, 7), (2, 7) ... (9, 7),
+       (9, 6), (9, 5) ... (9, 0),
+       (8, 0), (7, 0) ... (1, 0),
+       (0, 0) # Back to (0, 0) if closed=True
+
+    """
+    nx, ny = shape_(shape).xy
+    ix, iy = 0, 0
+    for ix in range(nx):
+        yield (0, ix)
+    for iy in range(1, ny):
+        yield (iy, ix)
+    for ix in range(ix - 1, -1, -1):
+        yield (iy, ix)
+    for iy in range(iy - 1, 0, -1):
+        yield (iy, ix)
+    if closed:
+        yield (0, 0)
 class Bin1D:
     """
     Class for translating continous coordinates to bin index.

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -23,6 +23,18 @@ T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 
 
+class Unset:
+    """
+    Marker for unset values.
+
+    Used where ``None`` can be a valid value.
+    """
+
+    # pylint: disable=too-few-public-methods
+
+    __slots__ = ()
+
+
 class XY(Generic[T]):
     """
     Immutable container for anything X/Y.

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -21,7 +21,7 @@ from odc.geo.crs import (
 )
 from odc.geo.geom import common_crs
 from odc.geo.testutils import epsg3577, epsg3857, epsg4326
-from odc.geo.types import xy_
+from odc.geo.types import Unset, xy_
 
 # pylint: disable=missing-class-docstring,use-implicit-booleaness-not-comparison
 # pylint: disable=comparison-with-itself
@@ -228,6 +228,15 @@ def test_rio_crs__no_epsg():
         'UNIT["Meter",1],AXIS["Easting",EAST],AXIS["Northing",NORTH]]'
     )
     assert CRS(rio_crs).epsg is None
+
+
+def test_norm_crs():
+    assert norm_crs(None) is None
+    assert norm_crs(Unset()) is None
+
+    for v in [None, Unset()]:
+        with pytest.raises(ValueError):
+            _ = norm_crs_or_error(v)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -546,3 +546,18 @@ def test_enclosing():
 
     with pytest.raises(ValueError):
         _ = gbox.enclosing(geom.point(0, 0, None))
+
+
+@pytest.mark.parametrize("n", [10, 100, 23])
+@pytest.mark.parametrize("with_edges", [False, True])
+def test_qr2sample(n, with_edges):
+    gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))
+    xx1 = gbox.qr2sample(n, with_edges=with_edges)
+    xx1_ = gbox.qr2sample(n, with_edges=with_edges)
+    xx2 = gbox.qr2sample(n, with_edges=with_edges, offset=1000)
+    assert xx1.crs is None
+    assert (xx1 ^ xx1_).is_empty
+    assert not (xx1 ^ xx2).is_empty
+    assert (gbox.project(xx1) - gbox.extent).is_empty
+    assert (xx1 - gbox.project(gbox.extent)).is_empty
+    assert (xx2 - gbox.project(gbox.extent)).is_empty

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -12,7 +12,6 @@ from pytest import approx
 from shapely.errors import ShapelyDeprecationWarning
 
 from odc.geo import CRS, CRSMismatchError, geom, wh_
-from odc.geo.crs import norm_crs, norm_crs_or_error
 from odc.geo.geobox import GeoBox, _round_to_res
 from odc.geo.geom import (
     chop_along_antimeridian,
@@ -742,11 +741,6 @@ def test_base_internals():
     assert _round_to_res(0.2, 1.0) == 1
     assert _round_to_res(0.0, 1.0) == 0
     assert _round_to_res(0.05, 1.0) == 0
-
-    assert norm_crs(None) is None
-
-    with pytest.raises(ValueError):
-        norm_crs_or_error(None)
 
 
 def test_geom_clone():

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -930,6 +930,33 @@ def test_filter():
 
 
 @pytest.mark.parametrize("crs", [None, "epsg:4326"])
+@pytest.mark.parametrize("n", [10, 100, 23])
+@pytest.mark.parametrize("with_edges", [False, True])
+def test_qr2sample(crs, n, with_edges):
+    bbox = geom.BoundingBox(10, 33, 21, 55, crs)
+
+    def run_checks(g: geom.Geometry):
+        assert g.crs == bbox.crs
+        assert (g - bbox.polygon).is_empty
+        assert g.is_multi
+        assert g.type == "MultiPoint"
+        if with_edges is False:
+            assert len(list(g.geoms)) == n
+        else:
+            assert len(list(g.geoms)) > n
+            assert (bbox.polygon - triangulate(g)).is_empty
+
+    xx1 = bbox.qr2sample(n, with_edges=with_edges)
+    xx2 = bbox.qr2sample(n, offset=100, with_edges=with_edges)
+    assert not (xx1 ^ xx2).is_empty
+    run_checks(xx1)
+    run_checks(xx2)
+
+    xx1_ = bbox.qr2sample(n, with_edges=with_edges)
+    assert (xx1 ^ xx1_).is_empty
+
+
+@pytest.mark.parametrize("crs", [None, "epsg:4326"])
 def test_triangulate(crs):
     bbox = geom.BoundingBox(0, 0, 1, 1, crs)
 

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -752,6 +752,25 @@ def test_geom_clone():
     assert b.geom is not geom.Geometry(b).geom
 
 
+@pytest.mark.parametrize("crs", [None, epsg4326])
+@pytest.mark.parametrize("nside", [3, 7, 10])
+def test_bbox_boundary(crs, nside):
+    n_pts_expect = (nside - 1) * 4
+    bbox = geom.BoundingBox(0, 20, 11, 29, crs)
+    poly = bbox.polygon
+    bb = bbox.boundary()
+    assert bb.crs == bbox.crs
+    assert bb.is_ring
+    assert bb.type == "LineString"
+    assert len(bb.coords[:-1]) == 4
+    assert (poly.exterior ^ bbox.boundary()).is_empty
+    assert (bbox.boundary() - poly).is_empty
+
+    bb = bbox.boundary(nside)
+    assert n_pts_expect == len(bb.coords[:-1])
+    assert (bbox.boundary() - poly).is_empty
+
+
 def test_lonlat_bounds():
     # example from landsat scene: spans lon=180
     poly = geom.box(618300, -1876800, 849000, -1642500, "EPSG:32660")

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -139,6 +139,10 @@ def test_ops():
     union1 = box1.union(box2)
     assert union1.area == 600.0
 
+    assert box1.crs == epsg4326
+    assert box1.assign_crs(None).crs is None
+    assert box1.assign_crs(None).geom is box1.geom
+
     with pytest.raises(geom.CRSMismatchError):
         box1.union(box2.to_crs(epsg3857))
 
@@ -865,6 +869,9 @@ def test_mul_affine():
     mg = geom.multigeom([g, g, g])
     assert mg.is_multi
     assert mg.transform(x10).is_multi
+    assert mg.transform(x10).crs == mg.crs
+    assert mg.transform(x10, crs=None).crs is None
+
     with pytest.warns(DeprecationWarning):
         assert x10 * mg == mg.transform(x10)
 

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -7,6 +7,7 @@ from affine import Affine
 from odc.geo import XY, resxy_, xy_
 from odc.geo.math import (
     Bin1D,
+    Poly2d,
     affine_from_axis,
     align_down,
     align_up,
@@ -15,6 +16,7 @@ from odc.geo.math import (
     is_almost_int,
     maybe_int,
     maybe_zero,
+    quasi_random_r2,
     resolution_from_affine,
     snap_affine,
     snap_grid,
@@ -279,3 +281,34 @@ def test_split_float(ab, expect_a, expect_b):
 
     assert a == pytest.approx(expect_a)
     assert (a + b) == pytest.approx(ab)
+
+
+@pytest.mark.parametrize(
+    "n",
+    [3, 1, 10, 100],
+)
+@pytest.mark.parametrize("ny", [30, 101])
+@pytest.mark.parametrize("nx", [20, 104])
+@pytest.mark.parametrize("offset", [0, 1, 103])
+def test_quasi_random_r2(n, ny, nx, offset):
+    xx = quasi_random_r2(n)
+    assert xx.shape == (n, 2)
+    assert xx.min() >= 0
+    assert xx.max() < 1
+
+    np.testing.assert_array_equal(xx, quasi_random_r2(n))
+
+    yy = quasi_random_r2(n, offset=offset)
+    assert yy.shape == (n, 2)
+    assert yy.min() >= 0
+    assert yy.max() < 1
+    np.testing.assert_array_equal(yy, quasi_random_r2(n, offset=offset))
+    if offset == 0:
+        np.testing.assert_array_equal(xx, yy)
+    else:
+        assert not (xx == yy).all()
+
+    xx = quasi_random_r2(n, shape=(ny, nx))
+    assert xx.min() >= 0
+    assert xx[:, 0].max() < nx
+    assert xx[:, 1].max() < ny


### PR DESCRIPTION
### GCP

When fitting polynomial use lower rank if only few points available.

Closes #67 

### New features

- `BoundingBox.boundary()` generate points along the perimiter
- `{BoundingBox|GeoBox}.qr2sample` quasi-random 2d sampling using [R2 sequence](http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/)
- `Geometry.assign_crs` use different CRS without changing geometry itself
- `Geometry.transform(..., crs=)` can now optionally change CRS of the transformed geometry
- `odc.geo.geom.triangulate` wrapper for for shapely method
- `MaybeCRS` now includes special `Unset` case to differentiate from `None`
- More robust `Geometry.geojson` (support composite and `crs=None` geometries)
- `rio_geobox` helper method in converters
