### PR TITLE
Maintenance: pyproj lower bound, workflows, css tweaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,7 +218,7 @@ jobs:
         if: |
           github.repository == 'opendatacube/odc-geo'
 
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
           verbose: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: wheels_cache
         with:
           path: ./wheels
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -101,9 +101,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -125,9 +125,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -154,9 +154,9 @@ jobs:
       - build-test-env-base
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -180,10 +180,10 @@ jobs:
       - run-black-check
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -232,17 +232,17 @@ jobs:
       - build-wheels
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Wheels from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: wheels_cache
         with:
           path: ./wheels
           key: wheels-${{ github.sha }}
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env
@@ -279,10 +279,10 @@ jobs:
       - run-black-check
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Conda Environment from Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: conda_cache
         with:
           path: /tmp/test_env

--- a/odc/geo/data/gbox.css
+++ b/odc/geo/data/gbox.css
@@ -1,6 +1,6 @@
 .gbox-info {
     max-width: 600px;
-    margin-left: 1em;
+    margin-left: 0.5em;
 }
 
 .gbox-info .column {
@@ -24,7 +24,6 @@
 
 .gbox-info .info-box {
     max-width: 200px;
-    margin-left: 1em;
 }
 
 .gbox-info .wkt {

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -505,7 +505,7 @@ class GeoBox(GeoBoxBase):
            Span that many pixels, if it's a single number then span that many pixels along the
            longest dimension, other dimension will be computed to maintain roughly square pixels.
 
-         :param crs:
+        :param crs:
            CRS to use, if different from the geopolygon
 
         :param align:

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -500,8 +500,6 @@ class Geometry(SupportsCoords[float]):
     @wrap_shapely
     def __sub__(self, other: "Geometry") -> "Geometry": return self.__sub__(other)
 
-    def svg(self, *args, **kw) -> str: return self.geom.svg(*args, *kw)
-
     def _repr_svg_(self) -> str: return self.geom._repr_svg_()
 
     @property
@@ -802,6 +800,23 @@ class Geometry(SupportsCoords[float]):
         Map geometry points through linear transform ``A*g``.
         """
         return self.transform(A)
+
+    def svg(self, *args, **kw) -> str:
+        """
+        Returns SVG path element (wraps shapely).
+
+        This method will drop parameters not supported by the underlying shapely geometry.
+
+        :param scale_factor: Multiplication factor for the SVG stroke-width.  Default is 1
+        :param stroke_color: Color for lines and rings
+        :param fill_color: Color for poinits and polygons
+        :param opacity: Float number between 0 and 1 for color opacity. Default value is 0.6
+        """
+        from inspect import signature  # pylint: disable=import-outside-toplevel
+
+        valid_params = signature(self.geom.svg).parameters
+        opts = {k: v for k, v in kw.items() if k in valid_params}
+        return self.geom.svg(*args, **opts)
 
     def svg_path(self, ndecimal: int = 6) -> str:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,6 @@ disable = [
   "fixme",
   "wrong-import-order",
   "cyclic-import",
+  "ungrouped-imports",
+  "wrong-import-position",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     affine
     cachetools
     numpy
-    pyproj
+    pyproj>=3.0.0
     shapely
 
 [options.extras_require]

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -22,7 +22,7 @@ dependencies:
   - mock
   - mypy
   - pycodestyle
-  - pylint
+  - pylint =2.14
   - types-cachetools
   - types-certifi
 


### PR DESCRIPTION
- `pyproj`: set lower bound to pyproj>=3, this is due to use of `pyproj.aoi` imports
- Upgrade some github action versions in workflows
- Pin pylint, newest one crashes on `_cog.py`
- Tweak CSS for Geobox display (smaller margins)
- Tweaks for `Geometry.svg` method, in now allows pass-through of parameters to the underlying shapely geometry