### PR TITLE
Implement geobox.zoom_to(resolution=) overload #79

### DIFF
--- a/odc/geo/gcp.py
+++ b/odc/geo/gcp.py
@@ -11,7 +11,7 @@ from .crs import CRS, MaybeCRS, SomeCRS, norm_crs
 from .geobox import GeoBox, GeoBoxBase
 from .geom import Geometry, multipoint
 from .math import Poly2d, affine_from_pts, align_up, resolution_from_affine, unstack_xy
-from .types import XY, MaybeInt, Resolution, SomeShape, wh_
+from .types import XY, MaybeInt, Resolution, SomeResolution, SomeShape, wh_
 
 SomePointSet = Union[np.ndarray, Geometry, List[Geometry], List[XY[float]]]
 
@@ -255,7 +255,12 @@ class GCPGeoBox(GeoBoxBase):
         _shape, _affine = self.compute_zoom_out(factor)
         return GCPGeoBox(_shape, self._mapping, _affine)
 
-    def zoom_to(self, shape: Union[SomeShape, int, float]) -> "GCPGeoBox":
+    def zoom_to(
+        self,
+        shape: Union[SomeShape, int, float, None] = None,
+        *,
+        resolution: Optional[SomeResolution] = None,
+    ) -> "GCPGeoBox":
         """
         Compute :py:class:`~odc.geo.geobox.GCPGeoBox` with changed resolution.
 
@@ -264,7 +269,7 @@ class GCPGeoBox(GeoBoxBase):
         :returns:
           GCPGeoBox covering the same region but with different number of pixels and therefore resolution.
         """
-        _shape, _affine = self.compute_zoom_to(shape)
+        _shape, _affine = self.compute_zoom_to(shape, resolution=resolution)
         return GCPGeoBox(_shape, self._mapping, _affine)
 
     def __str__(self):

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -309,7 +309,10 @@ class GeoBoxBase:
         return (shape_((ny, nx)), A)
 
     def compute_zoom_to(
-        self, shape: Union[SomeShape, int, float]
+        self,
+        shape: Union[SomeShape, int, float, None] = None,
+        *,
+        resolution: Optional[SomeResolution] = None,
     ) -> Tuple[Shape2d, Affine]:
         """
         Change GeoBox shape.
@@ -319,6 +322,14 @@ class GeoBoxBase:
         :returns:
           GeoBox covering the same region but with different number of pixels and therefore resolution.
         """
+        if shape is None:
+            if resolution is None:
+                raise ValueError("Have to supply shape or resolution")
+            new_geobox = GeoBox.from_bbox(
+                self.boundingbox, resolution=resolution, tight=True
+            )
+            return new_geobox.shape, new_geobox.affine
+
         if isinstance(shape, (int, float)):
             nmax = max(*self._shape)
             return self.compute_zoom_out(nmax / shape)
@@ -834,7 +845,12 @@ class GeoBox(GeoBoxBase):
         _shape, _affine = self.compute_zoom_out(factor)
         return GeoBox(_shape, _affine, self._crs)
 
-    def zoom_to(self, shape: Union[SomeShape, int, float]) -> "GeoBox":
+    def zoom_to(
+        self,
+        shape: Union[SomeShape, int, float, None] = None,
+        *,
+        resolution: Optional[SomeResolution] = None,
+    ) -> "GeoBox":
         """
         Change GeoBox shape.
 
@@ -843,7 +859,7 @@ class GeoBox(GeoBoxBase):
         :returns:
           GeoBox covering the same region but with different number of pixels and therefore resolution.
         """
-        _shape, _affine = self.compute_zoom_to(shape)
+        _shape, _affine = self.compute_zoom_to(shape, resolution=resolution)
         return GeoBox(_shape, _affine, self._crs)
 
     def flipy(self) -> "GeoBox":
@@ -1130,9 +1146,14 @@ def zoom_out(gbox: GeoBox, factor: float) -> GeoBox:
     return gbox.zoom_out(factor)
 
 
-def zoom_to(gbox: GeoBox, shape: SomeShape) -> GeoBox:
+def zoom_to(
+    gbox: GeoBox,
+    shape: Union[SomeShape, int, float, None] = None,
+    *,
+    resolution: Optional[SomeResolution] = None,
+) -> GeoBox:
     """Alias for :py:meth:`odc.geo.geobox.GeoBox.zoom_to`."""
-    return gbox.zoom_to(shape)
+    return gbox.zoom_to(shape, resolution=resolution)
 
 
 def rotate(gbox: GeoBox, deg: float) -> GeoBox:


### PR DESCRIPTION
Construct GeoBox covering almost the same area as the original but with pixels of the specified resolution.

Closes #79