### PR TITLE
Dask based implemenetation of reproject

### DIFF
--- a/docs/api-geobox.rst
+++ b/docs/api-geobox.rst
@@ -59,9 +59,12 @@ GeoboxTiles
    GeoboxTiles
    GeoboxTiles.base
    GeoboxTiles.chunk_shape
+   GeoboxTiles.chunks
    GeoboxTiles.range_from_bbox
    GeoboxTiles.shape
    GeoboxTiles.tiles
+   GeoboxTiles.grid_intersect
+   GeoboxTiles.roi
 
 
 Standalone Methods

--- a/odc/geo/_blocks.py
+++ b/odc/geo/_blocks.py
@@ -1,0 +1,108 @@
+# This file is part of the Open Data Cube, see https://opendatacube.org for more information
+#
+# Copyright (c) 2015-2023 ODC Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""
+Working with 2d+ chunks.
+"""
+from typing import Any, Mapping, Optional, Tuple
+
+import numpy as np
+
+from .roi import VariableSizedTiles
+from .types import Chunks2d
+
+
+class BlockAssembler:
+    """
+    Construct contigous 2+ dim array from incomplete set of YX blocks.
+    """
+
+    def __init__(
+        self,
+        blocks: Mapping[Tuple[int, int], np.ndarray],
+        chunks: Chunks2d,
+        axis: int = 0,
+    ) -> None:
+        self._shape = BlockAssembler._verify_shape(blocks, chunks, axis=axis)
+        self._dtype = (
+            np.dtype("float32")
+            if len(blocks) == 0
+            else np.find_common_type((b.dtype for b in blocks.values()), [])
+        )
+        self._axis = axis
+        self._blocks = blocks
+        self._tiles = VariableSizedTiles(chunks)
+        assert self._tiles.base.shape == self._shape[axis : axis + 2]
+
+    @staticmethod
+    def _verify_shape(
+        blocks: Mapping[Tuple[int, int], np.ndarray],
+        chunks: Chunks2d,
+        axis: int = 0,
+    ) -> Tuple[int, ...]:
+        """
+        compute total shape including prefix and postfix dimensions.
+        """
+        state: Optional[Tuple[int, Tuple[int, ...], Tuple[int, ...]]] = None
+        chy, chx = chunks
+        for (iy, ix), b in blocks.items():
+            if state is None:
+                if b.ndim < axis + 2:
+                    raise ValueError(
+                        f"Too few dimensions for `axis={axis}` ({b.ndim} < {axis+2})"
+                    )
+                state = (b.ndim, b.shape[:axis], b.shape[axis + 2 :])
+
+            if state[0] != b.ndim or state[1:] != (b.shape[:axis], b.shape[axis + 2 :]):
+                raise ValueError("Extra dimensions must be the same across all blocks")
+
+            yx_shape = b.shape[axis : axis + 2]
+            if yx_shape != (chy[iy], chx[ix]):
+                raise ValueError(f"Mismatched block YxX shape at [{iy}, {ix}]")
+
+        ny, nx = sum(chy), sum(chx)
+        if state is None:
+            return (ny, nx)
+        _, prefix, postfix = state
+        return (*prefix, ny, nx, *postfix)
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self._shape
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._dtype
+
+    @property
+    def ndim(self) -> int:
+        return len(self._shape)
+
+    def extract(
+        self,
+        fill_value: Any = None,
+        dtype=None,
+        casting="same_kind",
+    ) -> np.ndarray:
+        """
+        Paste all blocks together into one array possibly with type coercion.
+        """
+        if dtype is None:
+            dtype = self._dtype
+            if fill_value is not None:
+                # possibly upgrade to float based on fill_value
+                dtype = np.find_common_type([dtype], [np.min_scalar_type(fill_value)])
+
+        if fill_value is None:
+            fill_value = dtype.type("nan" if np.issubdtype(dtype, np.floating) else 0)
+
+        prefix = tuple([slice(None)] * self._axis)
+        postfix = tuple([slice(None)] * (self.ndim - self._axis - 2))
+
+        xx = np.full(self.shape, fill_value, dtype=dtype)
+        for idx, b in self._blocks.items():
+            roi = (*prefix, *self._tiles[idx], *postfix)
+            np.copyto(xx[roi], b, casting=casting)
+
+        return xx

--- a/odc/geo/_blocks.py
+++ b/odc/geo/_blocks.py
@@ -119,6 +119,8 @@ class BlockAssembler:
             if fill_value is not None:
                 # possibly upgrade to float based on fill_value
                 dtype = np.find_common_type([dtype], [np.min_scalar_type(fill_value)])
+        else:
+            dtype = np.dtype(dtype)
 
         if fill_value is None:
             fill_value = dtype.type("nan" if np.issubdtype(dtype, np.floating) else 0)

--- a/odc/geo/_dask.py
+++ b/odc/geo/_dask.py
@@ -1,0 +1,139 @@
+from functools import partial
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from uuid import uuid4
+
+import dask.array as da
+import numpy as np
+from dask.highlevelgraph import HighLevelGraph
+
+from ._blocks import BlockAssembler
+from .gcp import GCPGeoBox
+from .geobox import GeoBox, GeoboxTiles
+from .warp import Nodata, Resampling, _rio_reproject, resampling_s2rio
+
+
+def resolve_fill_value(dst_nodata, src_nodata, dtype):
+    dtype = np.dtype(dtype)
+
+    if dst_nodata is not None:
+        return dtype.type(dst_nodata)
+    if src_nodata is not None:
+        return dtype.type(src_nodata)
+    if np.issubdtype(dtype, np.floating):
+        return dtype.type("nan")
+    return dtype.type(0)
+
+
+def _do_chunked_reproject(
+    d2s: Dict[Tuple[int, int], Sequence[Tuple[int, int]]],
+    src_gbt: GeoboxTiles,
+    dst_gbt: GeoboxTiles,
+    dst_idx: Tuple[int, int],
+    *blocks: np.ndarray,
+    axis: int = 0,
+    dtype=None,
+    casting="same_kind",
+    resampling: Resampling = "nearest",
+    src_nodata: Nodata = None,
+    dst_nodata: Nodata = None,
+):
+    # pylint: disable=too-many-locals
+    src_gbt, src_idx = src_gbt.clip(d2s[dst_idx])
+    src_gbox = src_gbt.base
+    dst_gbox = dst_gbt[dst_idx]
+
+    ba = BlockAssembler(dict(zip(src_idx, blocks)), src_gbt.chunks, axis=axis)
+    if dtype is None:
+        dtype = ba.dtype
+
+    dst_shape = ba.with_yx(ba.shape, dst_gbox.shape)
+    dst = np.zeros(dst_shape, dtype=dtype)
+
+    for src_roi in ba.planes_yx():
+        src = ba.extract(src_nodata, dtype=dtype, casting=casting, roi=src_roi)
+        dst_roi = ba.with_yx(src_roi, np.s_[:, :])
+
+        _ = _rio_reproject(
+            src,
+            dst[dst_roi],
+            src_gbox,
+            dst_gbox,
+            resampling=resampling,
+            src_nodata=src_nodata,
+            dst_nodata=dst_nodata,
+        )
+
+    return dst
+
+
+def _dask_rio_reproject(
+    src: da.Array,
+    s_gbox: Union[GeoBox, GCPGeoBox],
+    d_gbox: GeoBox,
+    resampling: Resampling,
+    src_nodata: Nodata = None,
+    dst_nodata: Nodata = None,
+    ydim: int = 0,
+    chunks: Optional[Tuple[int, int]] = None,
+    **kwargs,
+) -> da.Array:
+    # pylint: disable=too-many-arguments, too-many-locals
+    if isinstance(resampling, str):
+        resampling = resampling_s2rio(resampling)
+
+    if chunks is None:
+        ny, nx = map(int, src.chunksize[ydim : ydim + 2])
+        chunks = (ny, nx)
+
+    def with_yx(a, yx):
+        return (*a[:ydim], *yx, *a[ydim + 2 :])
+
+    name: str = kwargs.get("name", "reproject")
+
+    assert isinstance(s_gbox, GeoBox)
+    gbt_src = GeoboxTiles(s_gbox, src.chunks[ydim : ydim + 2])
+    gbt_dst = GeoboxTiles(d_gbox, chunks)
+    d2s_idx = gbt_dst.grid_intersect(gbt_src)
+
+    dst_shape = with_yx(src.shape, d_gbox.shape.yx)
+    dst_chunks: Tuple[Tuple[int, ...], ...] = with_yx(src.chunks, gbt_dst.chunks)
+
+    tk = uuid4().hex
+    name = f"{name}-{tk}"
+    dsk: Dict[Any, Any] = {}
+
+    proc = partial(
+        _do_chunked_reproject,
+        d2s_idx,
+        gbt_src,
+        gbt_dst,
+        src_nodata=src_nodata,
+        dst_nodata=dst_nodata,
+        axis=ydim,
+    )
+    src_block_keys = src.__dask_keys__()
+
+    fill_value = resolve_fill_value(dst_nodata, src_nodata, src.dtype)
+
+    def _src(idx):
+        a = src_block_keys
+        for i in idx:
+            a = a[i]
+        return a
+
+    shape_in_blocks = tuple(map(len, dst_chunks))
+    for idx in np.ndindex(shape_in_blocks):
+        y, x = idx[ydim : ydim + 2]
+        srcs = [with_yx(idx, (y, x)) for y, x in d2s_idx.get((y, x), [])]
+
+        k = (name, *idx)
+        if srcs:
+            block_deps = tuple(_src(s_idx) for s_idx in srcs)
+            dsk[k] = (proc, (y, x), *block_deps)
+        else:
+            b_shape = tuple(ch[i] for ch, i in zip(dst_chunks, idx))
+            dsk[k] = (np.full, b_shape, fill_value, src.dtype)
+
+    dsk = HighLevelGraph.from_collections(name, dsk, dependencies=(src,))
+
+    return da.Array(dsk, name, chunks=dst_chunks, dtype=src.dtype, shape=dst_shape)

--- a/odc/geo/_dask.py
+++ b/odc/geo/_dask.py
@@ -41,6 +41,8 @@ def _do_chunked_reproject(
     src_gbt, src_idx = src_gbt.clip(d2s[dst_idx])
     src_gbox = src_gbt.base
     dst_gbox = dst_gbt[dst_idx]
+    assert isinstance(dst_gbox, GeoBox)
+    assert isinstance(src_gbox, (GCPGeoBox, GeoBox))
 
     ba = BlockAssembler(dict(zip(src_idx, blocks)), src_gbt.chunks, axis=axis)
     if dtype is None:

--- a/odc/geo/_version.py
+++ b/odc/geo/_version.py
@@ -1,2 +1,2 @@
 """version information only."""
-__version__ = "0.3.3"
+__version__ = "0.4.0a0"

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -24,10 +24,10 @@ from .math import (
     snap_grid,
     split_translation,
 )
-from .roi import Tiles as RoiTiles
-from .roi import align_up, roi_boundary, roi_normalise, roi_shape
+from .roi import RoiTiles, align_up, roi_boundary, roi_normalise, roi_shape, roi_tiles
 from .types import (
     XY,
+    Chunks2d,
     Index2d,
     MaybeInt,
     NormalizedROI,
@@ -1169,7 +1169,7 @@ def affine_transform_pix(gbox: GeoBox, transform: Affine) -> GeoBox:
 class GeoboxTiles:
     """Partition GeoBox into sub geoboxes."""
 
-    def __init__(self, box: GeoBox, tile_shape: SomeShape):
+    def __init__(self, box: GeoBox, tile_shape: Union[SomeShape, Chunks2d]):
         """
         Construct from a :py:class:`~odc.geo.GeoBox`.
 
@@ -1177,7 +1177,7 @@ class GeoboxTiles:
         :param tile_shape: Shape of sub-tiles in pixels ``(rows, cols)``
         """
         self._gbox = box
-        self._tiles = RoiTiles(box.shape, tile_shape)
+        self._tiles = roi_tiles(box.shape, tile_shape)
         self._cache: Dict[Index2d, GeoBox] = {}
 
     @property

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -1304,3 +1304,8 @@ class GeoboxTiles:
             *self._gbox.__dask_tokenize__()[1:],
             *self._tiles.__dask_tokenize__()[1:],
         )
+
+    def __str__(self):
+        return str(self.roi)
+
+    __repr__ = __str__

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -1291,6 +1291,6 @@ class GeoboxTiles:
     def __dask_tokenize__(self):
         return (
             "odc.geo.geobox.GeoboxTiles",
-            *self._tiles.shape.yx,
             *self._gbox.__dask_tokenize__()[1:],
+            *self._tiles.__dask_tokenize__()[1:],
         )

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -406,6 +406,9 @@ class GeoBoxBase:
             n, padding=padding, with_edges=with_edges, offset=offset
         )
 
+    def __getitem__(self, roi) -> "GeoBoxBase":
+        raise NotImplementedError()
+
 
 class GeoBox(GeoBoxBase):
     """
@@ -1191,7 +1194,7 @@ class GeoboxTiles:
 
     def __init__(
         self,
-        box: GeoBox,
+        box: GeoBoxBase,
         tile_shape: Union[SomeShape, Chunks2d, None],
         *,
         _tiles: Optional[RoiTiles] = None,
@@ -1210,7 +1213,7 @@ class GeoboxTiles:
             self._tiles = roi_tiles(box.shape, tile_shape)
 
     @property
-    def base(self) -> GeoBox:
+    def base(self) -> GeoBoxBase:
         """Access base Geobox"""
         return self._gbox
 
@@ -1265,7 +1268,7 @@ class GeoboxTiles:
     def crop(self) -> Mapping[ROI, "GeoboxTiles"]:
         return func2map(self._crop)
 
-    def __getitem__(self, idx: Union[SomeIndex2d, ROI]) -> GeoBox:
+    def __getitem__(self, idx: Union[SomeIndex2d, ROI]) -> GeoBoxBase:
         """
         Lookup tile by index, index is in matrix access order: ``(row, col)``.
 

--- a/odc/geo/overlap.py
+++ b/odc/geo/overlap.py
@@ -387,7 +387,7 @@ def _can_paste(
     if any(abs(abs(s) - 1) > stol for s in (sx, sy)):  # not equal scaling across axis?
         return False, "sx!=sy, probably"
 
-    # Check is sub-pixel translation is within bounds
+    # Check if sub-pixel translation within bounds
     if not all(is_almost_int(t, ttol) for t in (tx, ty)):
         return False, "sub-pixel translation"
 
@@ -610,7 +610,7 @@ def compute_output_geobox(
         #  Y = tr(X) => Y ~= s*X + t
         # where X is in `dst_` and Y is in `gbox`
         # .. so a better fit resolution is `_dst.res / s`
-        # .. but we want square pixels so pick average between x/y
+        # .. but we want square pixels, so pick average between x and y
         sx, sy = get_scale_at_point(xy_(0.5, 0.5), native_pix_transform(dst_, cp)).xy
 
         # always produces square pixels on output with inverted Y axis

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -552,6 +552,14 @@ def slice_intersect3(a: SomeSlice, b: SomeSlice) -> Tuple[slice, slice, slice]:
     )
 
 
+def roi_intersect3(
+    a: Tuple[SomeSlice, ...], b: Tuple[SomeSlice, ...]
+) -> Tuple[Tuple[slice, ...], Tuple[slice, ...], Tuple[slice, ...]]:
+    assert len(a) == len(b)
+    aa, bb, cc = zip(*[slice_intersect3(a_, b_) for a_, b_ in zip(a, b)])
+    return aa, bb, cc
+
+
 # fmt: off
 @overload
 def roi_normalise(roi: SomeSlice, shape: Union[int, Tuple[int]]) -> NormalizedSlice: ...

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -77,6 +77,9 @@ class RoiTiles(Protocol):
     def chunks(self) -> Chunks2d:
         ...
 
+    def __dask_tokenize__(self):
+        ...
+
 
 class Tiles:
     """
@@ -155,6 +158,13 @@ class Tiles:
             (nx,) * (NX - 1) + (nx_,),
         )
 
+    def __dask_tokenize__(self):
+        return (
+            "odc.geo.roi.Tiles",
+            *self._shape,
+            *self._tile_shape,
+        )
+
 
 class VariableSizedTiles:
     """
@@ -204,6 +214,12 @@ class VariableSizedTiles:
         """Dask compatible chunk rerpesentation."""
         y, x = (tuple(np.diff(idx).tolist()) for idx in self._offsets)
         return (y, x)
+
+    def __dask_tokenize__(self):
+        return (
+            "odc.geo.roi.VariableSizedTiles",
+            *self._offsets,
+        )
 
 
 def roi_tiles(shape: SomeShape, how: Union[SomeShape, Chunks2d]) -> RoiTiles:

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -523,6 +523,35 @@ def _norm_slice(s: SomeSlice, n: int) -> NormalizedSlice:
     return slice(start, stop, s.step)
 
 
+def slice_intersect3(a: SomeSlice, b: SomeSlice) -> Tuple[slice, slice, slice]:
+    """
+    Compute overlap 3 way.
+
+    Compute part of a that overlaps b, part of b that overlaps a and the region
+    of the original region covered by the overlap.
+
+    :returns: ``a', b', ab'``, such that ``X[a][a'] == X[b][b'] == X[ab']``
+    """
+    a = _norm_slice_or_error(a)
+    b = _norm_slice_or_error(b)
+    na = a.stop - a.start
+    nb = b.stop - b.start
+
+    if a.stop < b.start:
+        return slice(na, na), slice(0, 0), slice(a.stop, a.stop)
+    if a.start > b.stop:
+        return slice(0, 0), slice(nb, nb), slice(a.start, a.start)
+
+    _in = max(a.start, b.start)
+    _out = min(a.stop, b.stop)
+
+    return (
+        slice(_in - a.start, _out - a.start),
+        slice(_in - b.start, _out - b.start),
+        slice(_in, _out),
+    )
+
+
 # fmt: off
 @overload
 def roi_normalise(roi: SomeSlice, shape: Union[int, Tuple[int]]) -> NormalizedSlice: ...

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -60,7 +60,7 @@ class RoiTiles(Protocol):
     Abstraction for 2d slice/shape/chunks lookup.
     """
 
-    def __getitem__(self, idx: Union[SomeIndex2d, ROI]) -> NormalizedROI:
+    def __getitem__(self, idx: Union[SomeIndex2d, ROI]) -> Tuple[slice, slice]:
         ...
 
     def crop(self, roi: ROI) -> "RoiTiles":
@@ -115,8 +115,8 @@ class Tiles:
         base_shape = roi_shape(self[roi])
         return Tiles(base_shape, self._tile_shape)
 
-    def __getitem__(self, idx: Union[SomeIndex2d, ROI]) -> NormalizedROI:
-        def _slice(i: NormalizedSlice, N: int, n: int) -> NormalizedSlice:
+    def __getitem__(self, idx: Union[SomeIndex2d, ROI]) -> Tuple[slice, slice]:
+        def _slice(i: NormalizedSlice, N: int, n: int) -> slice:
             _in = i.start * n
             _out = i.stop * n
 
@@ -204,7 +204,7 @@ class VariableSizedTiles:
         y, x = (ch[s.start : s.stop] for ch, s in zip(self.chunks, roi))
         return VariableSizedTiles((y, x))
 
-    def __getitem__(self, idx: Union[SomeIndex2d, ROI]) -> NormalizedROI:
+    def __getitem__(self, idx: Union[SomeIndex2d, ROI]) -> Tuple[slice, slice]:
         idx = norm_slice_2d(idx, self.shape.yx)
         y, x = (
             slice(int(a[i.start]), int(a[i.stop])) for a, i in zip(self._offsets, idx)

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -94,6 +94,13 @@ def norm_slice_2d(
     return slice(y, y + 1), slice(x, x + 1)
 
 
+def _fmt_shape(shape):
+    n1, n2 = shape.yx
+    if max(n1, n2) > 10_000:
+        return f"{n1:_d}x{n2:_d}"
+    return f"{n1:d}x{n2:d}"
+
+
 class Tiles:
     """
     Partition box into tiles.
@@ -184,6 +191,13 @@ class Tiles:
             *self._tile_shape,
         )
 
+    def __str__(self) -> str:
+        b1, b2, b3 = map(_fmt_shape, [self._shape, self._tile_shape, self._base_shape])
+        return f"Tiles: {b1}|{b2}px => {b3}px"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
 
 class VariableSizedTiles:
     """
@@ -246,6 +260,13 @@ class VariableSizedTiles:
             "odc.geo.roi.VariableSizedTiles",
             *self._offsets,
         )
+
+    def __str__(self) -> str:
+        b1, b2, b3 = map(_fmt_shape, [self.shape, self.tile_shape((0, 0)), self.base])
+        return f"Tiles: {b1}|chunked {b2}px => {b3}px"
+
+    def __repr__(self) -> str:
+        return self.__str__()
 
 
 def roi_tiles(shape: SomeShape, how: Union[SomeShape, Chunks2d]) -> RoiTiles:

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -555,6 +555,14 @@ def slice_intersect3(a: SomeSlice, b: SomeSlice) -> Tuple[slice, slice, slice]:
 def roi_intersect3(
     a: Tuple[SomeSlice, ...], b: Tuple[SomeSlice, ...]
 ) -> Tuple[Tuple[slice, ...], Tuple[slice, ...], Tuple[slice, ...]]:
+    """
+    Compute overlap 3 way.
+
+    Compute part of a that overlaps b, part of b that overlaps a and the region
+    of the original region covered by the overlap.
+
+    :returns: ``a', b', ab'``, such that ``X[a][a'] == X[b][b'] == X[ab']``
+    """
     assert len(a) == len(b)
     aa, bb, cc = zip(*[slice_intersect3(a_, b_) for a_, b_ in zip(a, b)])
     return aa, bb, cc

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -222,6 +222,7 @@ class Shape2d(XY[int], Sequence[int]):
 SomeShape = Union[Tuple[int, int], XY[int], Shape2d, Index2d]
 SomeIndex2d = Union[Tuple[int, int], XY[int], Index2d]
 SomeResolution = Union[float, int, Resolution]
+Chunks2d = Tuple[Tuple[int, ...], Tuple[int, ...]]
 
 
 class SupportsCoords(Protocol[T]):

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -397,7 +397,7 @@ def wh_(w: int, h: int, /) -> Shape2d:
     return Shape2d(x=w, y=h)
 
 
-def shape_(x: SomeShape) -> Shape2d:
+def shape_(x: Union[SomeShape, Tuple[int, ...]]) -> Shape2d:
     """Normalise shape representation."""
     if isinstance(x, Shape2d):
         return x

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 import xarray as xr
 
-from odc.geo.data import ocean_geom
+from odc.geo.data import country_geom, ocean_geom
 from odc.geo.geobox import GeoBox
 from odc.geo.xr import rasterize
 
@@ -31,3 +31,18 @@ def ocean_raster_ds(ocean_raster: xr.DataArray) -> xr.Dataset:
             blue=xx,
         )
     )
+
+
+@pytest.fixture()
+def iso3():
+    return "AUS"
+
+
+@pytest.fixture()
+def crs():
+    return "epsg:3857"
+
+
+@pytest.fixture()
+def country(iso3, crs):
+    return country_geom(iso3, crs=crs)

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -39,7 +39,7 @@ dependencies:
   - rioxarray
 
   # for docs
-  - sphinx
+  - sphinx < 7
   - sphinx_rtd_theme
   - sphinx-autodoc-typehints
   - jupyter_sphinx

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -22,6 +22,8 @@ def test_block_assembler(tiles: RoiTiles, idx, dtype):
     Z = np.zeros(tiles.base.shape, dtype)
     for v, _i in enumerate(idx, start=1):
         Z[tiles[_i]] = v
+    Zf = Z.astype(np.floating).copy()
+    Zf[Z == 0] = np.nan
 
     blocks = {i: Z[tiles[i]].copy() for i in idx}
     ba = BlockAssembler(blocks, tiles.chunks)
@@ -37,11 +39,10 @@ def test_block_assembler(tiles: RoiTiles, idx, dtype):
         np.testing.assert_equal(Z, ba[:, :])
         np.testing.assert_equal(Z[:10, :3], ba[:10, :3])
         np.testing.assert_equal(Z[1:-1, 2:-3], ba[1:-1, 2:-3])
+        np.testing.assert_array_equal(ba.extract(dtype="float32"), Zf)
 
     # for floats default fill value is nan
     if np.issubdtype(dtype, np.floating):
-        Zf = Z.copy()
-        Zf[Z == 0] = np.nan
         np.testing.assert_array_equal(Zf, ba.extract())
         np.testing.assert_array_equal(Zf, ba[:, :])
         np.testing.assert_equal(Zf[:10, 3:], ba[:10, 3:])

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+
+from odc.geo._blocks import BlockAssembler
+from odc.geo.roi import RoiTiles, roi_tiles
+
+
+@pytest.mark.parametrize(
+    "tiles, idx",
+    [
+        (
+            roi_tiles((101, 203), (11, 13)),
+            [(0, 0), (1, 1), (2, 3)],
+        )
+    ],
+)
+@pytest.mark.parametrize("dtype", ["int8", "uint16", "float32"])
+def test_block_assembler(tiles: RoiTiles, idx, dtype):
+    dtype = np.dtype(dtype)
+    Z = np.zeros(tiles.base.shape, dtype)
+    for v, _i in enumerate(idx, start=1):
+        Z[tiles[_i]] = v
+
+    blocks = {i: Z[tiles[i]].copy() for i in idx}
+    ba = BlockAssembler(blocks, tiles.chunks)
+    assert ba.shape == Z.shape
+    assert ba.ndim == Z.ndim
+    assert ba.dtype == dtype
+
+    np.testing.assert_equal(Z, ba.extract(0))
+
+    # for ints default fill value is 0
+    if np.issubdtype(dtype, np.integer):
+        np.testing.assert_equal(Z, ba.extract())
+
+    # for floats default fill value is nan
+    if np.issubdtype(dtype, np.floating):
+        Zf = Z.copy()
+        Zf[Z == 0] = np.nan
+        np.testing.assert_array_equal(Zf, ba.extract())
+
+    # test empty
+    ba = BlockAssembler({}, tiles.chunks)
+    assert ba.shape == tiles.base.shape
+    assert ba.ndim == 2
+    assert ba.dtype == "float32"
+
+    # axis in the wrong position
+    with pytest.raises(ValueError):
+        _ = BlockAssembler(blocks, chunks=tiles.chunks, axis=1)
+
+    ii = idx[-1]
+
+    # ndim mismatch
+    bb = dict(blocks.items())
+    bb[ii] = bb[ii][..., np.newaxis]
+    with pytest.raises(ValueError):
+        _ = BlockAssembler(bb, chunks=tiles.chunks)
+
+    # chunk size mismatch
+    bb = dict(blocks.items())
+    bb[ii] = bb[ii][:-2]
+    with pytest.raises(ValueError):
+        _ = BlockAssembler(bb, chunks=tiles.chunks)

--- a/tests/test_dask_interop.py
+++ b/tests/test_dask_interop.py
@@ -24,6 +24,10 @@ def test_tokenize_geobox():
         GeoboxTiles(gbox.pad(1), (1, 2))
     )
 
+    gbt = GeoboxTiles(gbox, ((30, 40, 30), (45, 55)))
+    assert tokenize(gbt) == tokenize(GeoboxTiles(gbox, gbt.chunks))
+    assert tokenize(gbt) != tokenize(GeoboxTiles(gbox, gbt.chunks[::-1]))
+
     crs = CRS("epsg:4326")
     assert tokenize(crs) == tokenize(crs)
     assert tokenize(crs) == tokenize(CRS(crs))

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -6,15 +6,12 @@ import numpy as np
 import pytest
 from affine import Affine
 
-from odc.geo import CRSMismatchError
 from odc.geo import geobox as gbx
-from odc.geo import geom as geometry
 from odc.geo import wh_
 from odc.geo.geobox import GeoBox
+from odc.geo.testutils import epsg3857
 
 # pylint: disable=pointless-statement,too-many-statements
-
-epsg3857 = geometry.CRS("EPSG:3857")
 
 
 def test_gbox_ops():
@@ -143,65 +140,3 @@ def test_gbox_ops():
     assert s[49:52, 499:502].extent.contains(
         d[50:51, 500:501].extent
     ), "Check that center pixel hasn't moved"
-
-
-@pytest.mark.parametrize("use_chunks", [False, True])
-def test_gbox_tiles(use_chunks):
-    A = Affine.identity()
-    H, W = (300, 200)
-    h, w = (10, 20)
-    gbox = GeoBox(wh_(W, H), A, epsg3857)
-    tt = gbx.GeoboxTiles(gbox, (h, w))
-    assert tt.shape == (300 / 10, 200 / 20)
-    assert tt.base is gbox
-
-    if use_chunks:
-        tt = gbx.GeoboxTiles(gbox, tt.roi.chunks)
-
-    assert tt[0, 0] == gbox[0:h, 0:w]
-    assert tt[0, 1] == gbox[0:h, w : w + w]
-
-    assert tt[0, 0] is tt[0, 0]  # Should cache exact same object
-    assert tt[4, 1].shape == (h, w)
-
-    H, W = (11, 22)
-    h, w = (10, 9)
-    gbox = GeoBox(wh_(W, H), A, epsg3857)
-    tt = gbx.GeoboxTiles(gbox, (h, w))
-    assert tt.shape == (2, 3)
-    assert tt[1, 2] == gbox[10:11, 18:22]
-
-    # check .roi
-    assert tt.base[tt.roi[1, 2]] == tt[1, 2]
-
-    for idx in [tt.shape, (-1, 0), (0, -1), (-33, 1)]:
-        with pytest.raises(IndexError):
-            tt[idx]
-
-        with pytest.raises(IndexError):
-            tt.chunk_shape(idx)
-
-    cc = np.zeros(tt.shape, dtype="int32")
-    for idx in tt.tiles(gbox.extent):
-        cc[idx] += 1
-    np.testing.assert_array_equal(cc, np.ones(tt.shape))
-
-    assert list(tt.tiles(gbox[:h, :w].extent)) == [(0, 0)]
-    assert list(tt.tiles(gbox[:h, :w].extent.to_crs("epsg:4326"))) == [(0, 0)]
-
-    (H, W) = (11, 22)
-    (h, w) = (10, 20)
-    tt = gbx.GeoboxTiles(GeoBox(wh_(W, H), A, epsg3857), (h, w))
-    assert tt.chunk_shape((0, 0)) == (h, w)
-    assert tt.chunk_shape((0, 1)) == (h, 2)
-    assert tt.chunk_shape((1, 1)) == (1, 2)
-    assert tt.chunk_shape((1, 0)) == (1, w)
-
-    # check that overhang get's clamped properly
-    assert tt.range_from_bbox(gbox.pad(2).boundingbox) == (
-        range(0, tt.shape[0]),
-        range(0, tt.shape[1]),
-    )
-
-    with pytest.raises(CRSMismatchError):
-        _ = tt.range_from_bbox(gbox.geographic_extent.boundingbox)

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -145,7 +145,8 @@ def test_gbox_ops():
     ), "Check that center pixel hasn't moved"
 
 
-def test_gbox_tiles():
+@pytest.mark.parametrize("use_chunks", [False, True])
+def test_gbox_tiles(use_chunks):
     A = Affine.identity()
     H, W = (300, 200)
     h, w = (10, 20)
@@ -153,6 +154,9 @@ def test_gbox_tiles():
     tt = gbx.GeoboxTiles(gbox, (h, w))
     assert tt.shape == (300 / 10, 200 / 20)
     assert tt.base is gbox
+
+    if use_chunks:
+        tt = gbx.GeoboxTiles(gbox, tt.roi.chunks)
 
     assert tt[0, 0] == gbox[0:h, 0:w]
     assert tt[0, 1] == gbox[0:h, w : w + w]

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -272,6 +272,10 @@ def test_gbox_boundary():
 
     assert geobox.map_bounds() == geobox.boundingbox.map_bounds()
 
+    geobox = GeoBox(wh_(6, 2), Affine.translation(0, 0), None)
+    assert geobox.boundingbox.crs is None
+    assert geobox.map_bounds() == geobox.boundingbox.map_bounds()
+
 
 def test_geobox_scale_down():
     crs = CRS("EPSG:3857")

--- a/tests/test_geoboxtiles.py
+++ b/tests/test_geoboxtiles.py
@@ -56,6 +56,14 @@ def test_gbox_tiles(use_chunks):
     assert isinstance(str(tt), str)
     assert isinstance(repr(tt), str)
 
+    # check ==
+    assert tt == tt
+    assert tt != "?"
+    if use_chunks:
+        assert tt == GeoboxTiles(tt.base, tt.chunks)
+    else:
+        assert tt == GeoboxTiles(tt.base, (h, w))
+
     assert tt[0, 0] == gbox[0:h, 0:w]
     assert tt[0, 1] == gbox[0:h, w : w + w]
 
@@ -120,3 +128,10 @@ def test_gbox_tiles_roi(use_chunks):
     assert tt[:, :] == gbox
     assert tt.crop[:, :].base == gbox
     assert tt.crop[1, 2].base == tt[1, 2]
+
+    assert tt.clip([(0, 0)]) == (tt.crop[0, 0], [(0, 0)])
+    assert tt.clip([(1, 0)]) == (tt.crop[1, 0], [(0, 0)])
+    assert tt.clip([(1, 2), (2, 5)]) == (
+        tt.crop[1 : 2 + 1, 2 : 5 + 1],
+        [(0, 0), (1, 3)],
+    )

--- a/tests/test_geoboxtiles.py
+++ b/tests/test_geoboxtiles.py
@@ -52,6 +52,10 @@ def test_gbox_tiles(use_chunks):
     if use_chunks:
         tt = GeoboxTiles(gbox, tt.roi.chunks)
 
+    # smoke test textual repr
+    assert isinstance(str(tt), str)
+    assert isinstance(repr(tt), str)
+
     assert tt[0, 0] == gbox[0:h, 0:w]
     assert tt[0, 1] == gbox[0:h, w : w + w]
 

--- a/tests/test_geoboxtiles.py
+++ b/tests/test_geoboxtiles.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from odc.geo import MaybeCRS, geom
+from odc.geo.geobox import GeoBox, GeoboxTiles
+
+
+@pytest.mark.parametrize(
+    "iso3, crs, resolution",
+    [
+        ("AUS", "epsg:4326", 0.1),
+        ("AUS", "epsg:3577", 10_000),
+        ("AUS", "epsg:3857", 10_000),
+        ("NZL", "epsg:3857", 1_000),
+    ],
+)
+def test_geoboxtiles_intersect(
+    country: geom.Geometry, resolution: float, crs: MaybeCRS
+):
+    assert isinstance(country, geom.Geometry)
+    assert country.crs == crs
+
+    geobox = GeoBox.from_geopolygon(country, resolution=resolution, tight=True)
+    assert geobox.crs == crs
+
+    gbt = GeoboxTiles(geobox, (11, 13))
+    assert gbt.base is geobox
+    mm = gbt.grid_intersect(gbt)
+
+    assert len(gbt.chunks) == 2
+    assert (sum(gbt.chunks[0]), sum(gbt.chunks[1])) == gbt.base.shape
+
+    for iy, ix in np.ndindex(gbt.shape.yx):
+        idx = (iy, ix)
+        assert idx in mm
+        assert len(mm[idx]) >= 1
+        assert idx in mm[idx]

--- a/tests/test_geoboxtiles.py
+++ b/tests/test_geoboxtiles.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
+from affine import Affine
 
-from odc.geo import MaybeCRS, geom
+from odc.geo import CRSMismatchError, MaybeCRS, geom, wh_
 from odc.geo.geobox import GeoBox, GeoboxTiles
+from odc.geo.testutils import epsg3857
 
 
 @pytest.mark.parametrize(
@@ -11,7 +13,7 @@ from odc.geo.geobox import GeoBox, GeoboxTiles
         ("AUS", "epsg:4326", 0.1),
         ("AUS", "epsg:3577", 10_000),
         ("AUS", "epsg:3857", 10_000),
-        ("NZL", "epsg:3857", 1_000),
+        ("NZL", "epsg:3857", 5_000),
     ],
 )
 def test_geoboxtiles_intersect(
@@ -35,3 +37,82 @@ def test_geoboxtiles_intersect(
         assert idx in mm
         assert len(mm[idx]) >= 1
         assert idx in mm[idx]
+
+
+@pytest.mark.parametrize("use_chunks", [False, True])
+def test_gbox_tiles(use_chunks):
+    A = Affine.identity()
+    H, W = (300, 200)
+    h, w = (10, 20)
+    gbox = GeoBox(wh_(W, H), A, epsg3857)
+    tt = GeoboxTiles(gbox, (h, w))
+    assert tt.shape == (300 / 10, 200 / 20)
+    assert tt.base is gbox
+
+    if use_chunks:
+        tt = GeoboxTiles(gbox, tt.roi.chunks)
+
+    assert tt[0, 0] == gbox[0:h, 0:w]
+    assert tt[0, 1] == gbox[0:h, w : w + w]
+
+    assert tt[4, 1].shape == (h, w)
+
+    H, W = (11, 22)
+    h, w = (10, 9)
+    gbox = GeoBox(wh_(W, H), A, epsg3857)
+    tt = GeoboxTiles(gbox, (h, w))
+    assert tt.shape == (2, 3)
+    assert tt[1, 2] == gbox[10:11, 18:22]
+
+    # check .roi
+    assert tt.base[tt.roi[1, 2]] == tt[1, 2]
+
+    for idx in [tt.shape, (-33, 1)]:
+        with pytest.raises(IndexError):
+            _ = tt[idx]
+
+        with pytest.raises(IndexError):
+            tt.chunk_shape(idx)
+
+    cc = np.zeros(tt.shape, dtype="int32")
+    for idx in tt.tiles(gbox.extent):
+        cc[idx] += 1
+    np.testing.assert_array_equal(cc, np.ones(tt.shape))
+
+    assert list(tt.tiles(gbox[:h, :w].extent)) == [(0, 0)]
+    assert list(tt.tiles(gbox[:h, :w].extent.to_crs("epsg:4326"))) == [(0, 0)]
+
+    (H, W) = (11, 22)
+    (h, w) = (10, 20)
+    tt = GeoboxTiles(GeoBox(wh_(W, H), A, epsg3857), (h, w))
+    assert tt.chunk_shape((0, 0)) == (h, w)
+    assert tt.chunk_shape((0, 1)) == (h, 2)
+    assert tt.chunk_shape((1, 1)) == (1, 2)
+    assert tt.chunk_shape((1, 0)) == (1, w)
+
+    # check that overhang get's clamped properly
+    assert tt.range_from_bbox(gbox.pad(2).boundingbox) == (
+        range(0, tt.shape[0]),
+        range(0, tt.shape[1]),
+    )
+
+    with pytest.raises(CRSMismatchError):
+        _ = tt.range_from_bbox(gbox.geographic_extent.boundingbox)
+
+
+@pytest.mark.parametrize("use_chunks", [False, True])
+def test_gbox_tiles_roi(use_chunks):
+    A = Affine.identity()
+    H, W = (300, 200)
+    h, w = (10, 20)
+    gbox = GeoBox(wh_(W, H), A, epsg3857)
+    tt = GeoboxTiles(gbox, (h, w))
+    assert tt.shape == (H // h, W // w)
+    assert tt.base is gbox
+
+    if use_chunks:
+        tt = GeoboxTiles(gbox, tt.roi.chunks)
+
+    assert tt[:, :] == gbox
+    assert tt.crop[:, :].base == gbox
+    assert tt.crop[1, 2].base == tt[1, 2]

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 from affine import Affine
 from pytest import approx
-from shapely.errors import ShapelyDeprecationWarning
 
 from odc.geo import CRS, CRSMismatchError, geom, wh_
 from odc.geo.geobox import GeoBox, _round_to_res
@@ -342,6 +341,7 @@ def test_to_crs():
     assert poly.to_crs(epsg3857).crs is epsg3857
     assert poly.to_crs("EPSG:3857").crs == "EPSG:3857"
     assert poly.to_crs("EPSG:3857", 0.1).crs == epsg3857
+    assert poly.to_crs(3857, "auto").crs == epsg3857
 
     assert poly.exterior.to_crs(epsg3857) == poly.to_crs(epsg3857).exterior
 
@@ -797,12 +797,11 @@ def test_lonlat_bounds():
     }
 
     multi_geom = geom.Geometry(multi, "epsg:4326")
-    multi_geom_projected = multi_geom.to_crs("epsg:32659", math.inf)
+    multi_geom_projected = multi_geom.to_crs("epsg:32659")
+    expect = approx(geom.lonlat_bounds(multi_geom))
 
-    ll_bounds = geom.lonlat_bounds(multi_geom)
-    ll_bounds_projected = geom.lonlat_bounds(multi_geom_projected)
-
-    assert ll_bounds == approx(ll_bounds_projected)
+    assert geom.lonlat_bounds(multi_geom_projected) == expect
+    assert geom.lonlat_bounds(multi_geom_projected, resolution="auto") == expect
 
 
 def test_geojson():

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -21,6 +21,7 @@ from odc.geo.roi import (
     scaled_down_roi,
     scaled_down_shape,
     scaled_up_roi,
+    slice_intersect3,
     w_,
 )
 
@@ -93,6 +94,38 @@ def test_roi_from_points():
     assert roi_from_points(xy, (100, 100)) == np.s_[1:22, 0:11]
     assert roi_from_points(xy, (5, 7)) == np.s_[1:5, 0:7]
     assert roi_from_points(xy[2:, :], (3, 3)) == np.s_[0:0, 0:0]
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        np.s_[0:3, :3],
+        np.s_[:4, 2:6],
+        np.s_[4:13, 5:17],
+        np.s_[10:13, 3:7],
+        np.s_[10:13, 13:17],
+        np.s_[10:13, 14:17],
+    ],
+)
+def test_slice_intersect3(a: slice, b: slice):
+    assert isinstance(a.stop, int)
+    assert isinstance(b.stop, int)
+    _a, _b, _ab = slice_intersect3(a, b)
+
+    (na,) = roi_shape(a)
+    (nb,) = roi_shape(b)
+
+    assert _a.start <= _a.stop
+    assert 0 <= _a.start <= na
+    assert 0 <= _a.stop <= na
+
+    assert _b.start <= _b.stop
+    assert 0 <= _b.start <= nb
+    assert 0 <= _b.stop <= nb
+
+    X = np.arange(max(a.stop, b.stop))
+    np.testing.assert_array_equal(X[a][_a], X[b][_b])
+    np.testing.assert_array_equal(X[a][_a], X[_ab])
 
 
 def test_roi_intersect():

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -321,3 +321,26 @@ def test_clip_tiles(tiles: RoiTiles):
     assert tt == tiles
     assert roi == np.s_[0:ny, 0:nx]
     assert idx == [tl, tr, br, bl]
+
+
+@pytest.mark.parametrize(
+    "tiles",
+    [
+        VariableSizedTiles(((10, 1, 30), (2, 4, 5, 6))),
+        VariableSizedTiles(((10, 1, 30), (2, 4, 7, 13))),
+        Tiles((104, 201), (11, 23)),
+    ],
+)
+def test_locate(tiles: RoiTiles):
+    NY, NX = tiles.base.yx
+    ny, nx = tiles.shape.yx
+
+    # check all four corners
+    assert tiles.locate((0, 0)) == (0, 0)
+    assert tiles.locate((NY - 1, NX - 1)) == (ny - 1, nx - 1)
+    assert tiles.locate((0, NX - 1)) == (0, nx - 1)
+    assert tiles.locate((NY - 1, 0)) == (ny - 1, 0)
+
+    for idx in [(-1, 0), (NY, 0), (NY, NX), (NY * 1000, 1)]:
+        with pytest.raises(IndexError):
+            _ = tiles.locate(idx)

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -64,6 +64,8 @@ def test_roi_tools():
     assert roi_normalise(s_[:4], (40,)) == s_[0:4]
     assert roi_normalise(s_[:], (40,)) == s_[0:40]
     assert roi_normalise(s_[:-1], (3,)) == s_[0:2]
+    assert roi_normalise(-1, (3,)) == s_[2:3]
+    assert roi_normalise(s_[-1:], (3,)) == s_[2:3]
     assert roi_normalise((s_[:-1],), 3) == (s_[0:2],)
     assert roi_normalise(s_[-2:-1, :], (10, 20)) == s_[8:9, 0:20]
     assert roi_normalise(s_[-2:-1, :, 3:4], (10, 20, 100)) == s_[8:9, 0:20, 3:4]
@@ -162,6 +164,10 @@ def test_tiles():
 
     assert tt[0, 0] == np.s_[0:3, 0:7]
     assert tt[3, 2] == np.s_[9:10, 14:20]
+    assert tt[-1, -1] == tt[3, 2]
+    assert tt[-4, -3] == tt[0, 0]
+    assert tt.tile_shape((-1, -1)) == tt.tile_shape((3, 2))
+    assert tt.tile_shape((-4, -3)) == tt.tile_shape((0, 0))
 
     assert tt[0, 0] == tt[:1, :1]
     assert tt[:, :] == np.s_[0:10, 0:20]
@@ -176,6 +182,10 @@ def test_tiles():
     assert tt_.shape.yx == (4, 3)
     assert tt_.base.yx == (10, 20)
     assert tt_.chunks == ((3, 3, 3, 1), (7, 7, 6))
+    assert tt[-1, -1] == tt[3, 2]
+    assert tt[-4, -3] == tt[0, 0]
+    assert tt.tile_shape((-1, -1)) == tt.tile_shape((3, 2))
+    assert tt.tile_shape((-4, -3)) == tt.tile_shape((0, 0))
 
     assert isinstance(roi_tiles(tt.shape, (1, 2)), Tiles)
     assert isinstance(roi_tiles(tt.shape, tt.shape), Tiles)

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -200,3 +200,5 @@ def test_varsz_tiles(chunks):
                 sum(ix[:x]) : sum(ix[: x + 1]),
             ]
         )
+
+    assert isinstance(tt.__dask_tokenize__(), tuple)

--- a/tests/test_roi.py
+++ b/tests/test_roi.py
@@ -181,6 +181,11 @@ def test_tiles():
     assert isinstance(roi_tiles(tt.shape, tt.shape), Tiles)
     assert isinstance(roi_tiles(tt.shape, tt.chunks), VariableSizedTiles)
 
+    # smoke test repr/str
+    assert isinstance(repr(tt), str)
+    assert isinstance(repr(tt_), str)
+    assert "100_123x200_321" in repr(Tiles((100_123, 200_321), (1000, 1000)))
+
 
 @pytest.mark.parametrize(
     "chunks",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,9 +1,11 @@
 from collections import abc
+from typing import Tuple
 
 import pytest
 
 from odc.geo import ixy_, iyx_, res_, resxy_, resyx_, shape_, wh_, xy_, yx_
 from odc.geo.geom import point
+from odc.geo.types import func2map
 
 
 def test_basics():
@@ -116,3 +118,20 @@ def test_map():
 
 def test_geom_interop():
     assert xy_(1.0, 2.0) == xy_(point(1.0, 2.0, "epsg:4326"))
+
+
+def test_func_to_map() -> None:
+    def aa(idx: int) -> Tuple[int, int]:
+        return (idx, idx + 1)
+
+    def first(idx: Tuple[int, ...]) -> int:
+        return idx[0]
+
+    AA = func2map(aa)
+    assert len(AA) == 0
+    assert list(AA) == []
+    assert AA[10] == aa(10)
+
+    FF = func2map(first)
+    assert FF[3, 2] == 3
+    assert FF[100, 3, 4] == 100

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -359,6 +359,10 @@ def test_wrap_xr():
     assert xx.time.dt.year.values[0] == 2022
     assert xx.time.dt.month.values[0] == 2
 
+    xx = wrap_xr(data[..., np.newaxis], gbox)
+    assert xx.shape == (*gbox.shape, 1)
+    assert xx.band.data.tolist() == ["b0"]
+
 
 def test_xr_reproject(xx_epsg4326: xr.DataArray):
     assert isinstance(xx_epsg4326.odc, ODCExtensionDa)


### PR DESCRIPTION
1. Generalize `GeoboxTiles` 
    - support arbitrary chunked grids
    - support `GCPGeoBox` input
    - support "clipping" of tiles
2. Implement `GeoboxTiles.grid_intersect` method for computing cross-block depenendencies
3. Implement `BlockAssembler` helper class
4. Implement Dask graph construction for reproject workflow using above

Closes #26

TODO:

- Address #87 
- Cache `grid_intersect` results when transforming multi-band Dask `xarray.Dataset`s that share common geometry of chunks across several bands to speed up Dask graph construction
- Proper unit testing for Dask reproject
