### PR TITLE
Address various depreactions and suppress some warnings

### DIFF
--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -2,7 +2,7 @@
 # odc-geo dependencies
 pyproj
 shapely
-rasterio==1.2.10
+rasterio==1.3.6
 xarray
 numpy
 cachetools
@@ -13,7 +13,7 @@ matplotlib
 dask[array]
 
 ## for docs
-sphinx<7
+sphinx
 sphinx_rtd_theme
 sphinx-autodoc-typehints
 jupyter_sphinx

--- a/odc/geo/_map.py
+++ b/odc/geo/_map.py
@@ -31,7 +31,7 @@ def _add_to_ipyleaflet(url, bounds, map, name=None, **kw):
         kw.update(name=name)
 
     img_overlay = ImageOverlay(url=url, bounds=bounds, **kw)
-    map.add_layer(img_overlay)
+    map.add(img_overlay)
 
     return img_overlay
 

--- a/odc/geo/_rgba.py
+++ b/odc/geo/_rgba.py
@@ -164,11 +164,11 @@ def _np_colorize(x, cmap, clip):
 
 
 def _matplotlib_colorize(x, cmap, vmin=None, vmax=None, nodata=None, robust=False):
-    from matplotlib import cm
+    from matplotlib import colormaps
     from matplotlib.colors import Normalize
 
     if cmap is None or isinstance(cmap, str):
-        cmap = cm.get_cmap(cmap)
+        cmap = colormaps.get_cmap(cmap)
 
     if nodata is not None:
         x = np.where(x == nodata, np.float32("nan"), x)

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -255,8 +255,8 @@ def xr_coords(
        CRS coordinate at all.
 
     :returns:
-      Dictionary ``name:str -> xr.DataArray``. Where names are either ``y,x`` for projected or
-      ``latitude, longitude`` for geographic.
+       Dictionary ``name:str -> xr.DataArray``. Where names are either ``y,x`` for projected or
+       ``latitude, longitude`` for geographic.
 
     """
     attrs = {}

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -22,7 +22,7 @@ def test_block_assembler(tiles: RoiTiles, idx, dtype):
     Z = np.zeros(tiles.base.shape, dtype)
     for v, _i in enumerate(idx, start=1):
         Z[tiles[_i]] = v
-    Zf = Z.astype(np.floating).copy()
+    Zf = Z.astype(np.float32).copy()
     Zf[Z == 0] = np.nan
 
     blocks = {i: Z[tiles[i]].copy() for i in idx}

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,5 +1,6 @@
 # pylint: disable=wrong-import-position
 from pathlib import Path
+from warnings import catch_warnings, filterwarnings
 
 import pytest
 from mock import MagicMock
@@ -14,8 +15,16 @@ from odc.geo.gcp import GCPGeoBox
 from odc.geo.geobox import GeoBox, GeoBoxBase
 
 
-def test_from_geopandas():
-    df = gpd.read_file(gpd_datasets.get_path("naturalearth_lowres"))
+@pytest.fixture
+def ne_lowres_path():
+    with catch_warnings():
+        filterwarnings("ignore")
+        path = gpd_datasets.get_path("naturalearth_lowres")
+    yield path
+
+
+def test_from_geopandas(ne_lowres_path):
+    df = gpd.read_file(ne_lowres_path)
     gg = from_geopandas(df)
     assert isinstance(gg, list)
     assert len(gg) == len(df)

--- a/tests/test_rgba.py
+++ b/tests/test_rgba.py
@@ -9,7 +9,6 @@ from odc.geo.xr import ODCExtensionDa, ODCExtensionDs
 
 try:
     import matplotlib
-    import matplotlib.cm
 except ImportError:
     matplotlib = None
 
@@ -61,7 +60,7 @@ def test_colorize_matplotlib(ocean_raster: xr.DataArray):
     assert cc.dtype == "uint8"
     assert cc.shape == (*xx.shape, 4)
 
-    cc = xx.astype("float32").odc.colorize(matplotlib.cm.get_cmap("viridis"))
+    cc = xx.astype("float32").odc.colorize(matplotlib.colormaps.get_cmap("viridis"))
     assert isinstance(cc.odc, ODCExtensionDa)
     assert cc.odc.geobox == xx.odc.geobox
     assert cc.dtype == "uint8"


### PR DESCRIPTION
- ipyleaflet `add_layer -> add`
- matplotlib get_cmap
- suppress shapely warnings while clipping ocean geometry for geobox display