### PR TITLE
Fix layer name handing with Folium and `.odc.add_to()`

### DIFF
--- a/odc/geo/_map.py
+++ b/odc/geo/_map.py
@@ -15,8 +15,8 @@ def _add_to_folium(url, bounds, map, name=None, **kw):
 
     from folium.raster_layers import ImageOverlay
 
-    img_overlay = ImageOverlay(url, bounds, **kw)
-    img_overlay.add_to(map, name=name)
+    img_overlay = ImageOverlay(url, bounds, name=name, **kw)
+    img_overlay.add_to(map)
     return img_overlay
 
 


### PR DESCRIPTION
A small PR to close #99 by fixing where the `name` param is provided when using the Folium with `.add_to`.

Example code to verify fix:

```
import odc.geo.xr
import rioxarray
import folium

ds = rioxarray.open_rasterio(
    "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/derivative/dea_intertidal/sample_data/160/2019-2021/DEV_160_2019_2021_elevation.tif",
    masked=True,
).squeeze("band")

m = folium.Map()

ds.odc.add_to(m, name="test")
folium.LayerControl().add_to(m)
display(m)
```

Before: 
![image](https://github.com/opendatacube/odc-geo/assets/17680388/e61674d4-be70-4fe7-bf82-d8929d613a0b)

After:
![image](https://github.com/opendatacube/odc-geo/assets/17680388/9ac3193c-9c9d-439b-82f9-0d466e64ea48)
