### PR TITLE
Use xarray `.name` attribute as Folium/Ipyleaflet layer name if it exists

### DIFF
--- a/odc/geo/_map.py
+++ b/odc/geo/_map.py
@@ -109,7 +109,7 @@ def add_to(
 
     # If array xx has a name (xx.name), use it by default
     if (name is None) and (xx.name is not None):
-        name = xx.name
+        name = xx.name if isinstance(xx.name, str) else str(xx.name)
 
     gbox0 = xx.odc.geobox
     assert gbox0 is not None

--- a/odc/geo/_map.py
+++ b/odc/geo/_map.py
@@ -78,7 +78,7 @@ def add_to(
     :param map:
        Map object, :py:mod:`folium` and :py:mod:`ipyleaflet` are understood, can be ``None``.
 
-    :param name: Image layer name
+    :param name: The name of the layer as it will appear in :py:mod:`folium` and :py:mod:`ipyleaflet` Layer Controls. The default ``None`` will use the input array name (e.g. ``xx.name``) if it exists.
     :param fmt: compress image format, defaults to "png", can be "webp", "jpeg" as well.
     :param max_size:
        If longest dimension is bigger than this, shrink it down before compression, defaults to 4096
@@ -104,6 +104,10 @@ def add_to(
 
     _add_to = _get_add_to_method(map)  # raises on error
     _crs = map_crs(map)
+
+    # If array xx has a name (xx.name), use it by default
+    if (name is None) and (xx.name is not None):
+        name = xx.name
 
     gbox0 = xx.odc.geobox
     assert gbox0 is not None

--- a/odc/geo/_map.py
+++ b/odc/geo/_map.py
@@ -78,7 +78,9 @@ def add_to(
     :param map:
        Map object, :py:mod:`folium` and :py:mod:`ipyleaflet` are understood, can be ``None``.
 
-    :param name: The name of the layer as it will appear in :py:mod:`folium` and :py:mod:`ipyleaflet` Layer Controls. The default ``None`` will use the input array name (e.g. ``xx.name``) if it exists.
+    :param name:
+       The name of the layer as it will appear in :py:mod:`folium` and :py:mod:`ipyleaflet`
+       Layer Controls. The default ``None`` will use the input array name (e.g. ``xx.name``) if it exists.
     :param fmt: compress image format, defaults to "png", can be "webp", "jpeg" as well.
     :param max_size:
        If longest dimension is bigger than this, shrink it down before compression, defaults to 4096


### PR DESCRIPTION
This PR addresses #102 by updating the `odc.add_to()` method to use the `.name` attribute of the input array if it exists AND `name=None`.