### PR TITLE
Include full 2D scale (as XY) in ReprojectionInfo object.

### DIFF
--- a/odc/geo/overlap.py
+++ b/odc/geo/overlap.py
@@ -183,7 +183,10 @@ class ReprojectInfo:
     """
 
     scale: float
-    """Scale change as a single number."""
+    """Scale change as a single number. (the min of scale2)"""
+
+    scale2: XY[float]
+    """Full 2D Scale change as an XY."""
 
     transform: PointTransform
     """Mapping from src pixels to destination pixels."""
@@ -501,12 +504,14 @@ def compute_reproject_roi(
             read_shrink = _pick_read_scale(scale)
         else:
             scale = 0
+            scale2 = XY(x=0, y=0)
             read_shrink = 1
 
         return ReprojectInfo(
             roi_src=roi_src,
             roi_dst=roi_dst,
             scale=scale,
+            scale2=scale2,
             paste_ok=False,
             read_shrink=read_shrink,
             transform=tr,
@@ -546,6 +551,7 @@ def compute_reproject_roi(
         roi_src=roi_src,
         roi_dst=roi_dst,
         scale=scale,
+        scale2=scale2,
         paste_ok=paste_ok,
         read_shrink=read_shrink,
         transform=tr,

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -165,6 +165,7 @@ def test_compute_reproject_roi():
 
     assert rr.roi_src == np.s_[0 : src.height, 0 : src.width]
     assert 0 < rr.scale < 1
+    assert all(0 < scale < 1 for scale in rr.scale2.xy)
     assert rr.transform.linear is None
     assert rr.transform.back is not None
     assert rr.transform.back.linear is None
@@ -178,6 +179,7 @@ def test_compute_reproject_roi():
     rr = compute_reproject_roi(src, src[roi_], padding=0, align=0)
     assert rr.roi_src == roi_normalise(roi_, src.shape)
     assert rr.scale == 1
+    assert rr.scale2.xy == (1, 1)
 
     # check pure translation case
     roi_ = np.s_[113:-100, 33:-10]


### PR DESCRIPTION
I would like to be able to use the full 2D scale for calculating GDAL scale hints in `datacube-core`.  I have added it to the ReprojectionInfo object as `scale2`. 

(I also documented how `scale` is "calculated" from `scale2` in the dataclass).