### PR TITLE
Use conda-forge only for miniconda

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         if: steps.conda_cache.outputs.cache-hit != 'true'
         with:
-          channels: conda-forge,defaults
+          channels: conda-forge
           channel-priority: true
           activate-environment: ""
           mamba-version: "*"


### PR DESCRIPTION
only use `conda-forge` channel for building test environments.