### PR TITLE
Add new `odc.mask` and `odc.crop` methods for masking and cropping `xarray` data by geometries

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,8 @@ Interfacing with :py:class:`xarray.DataArray` and :py:class:`xarray.Dataset` cla
    ODCExtension.spatial_dims
    ODCExtension.crs
    ODCExtension.map_bounds
+   ODCExtension.crop
+   ODCExtension.mask
 
    ODCExtensionDa
    ODCExtensionDa.assign_crs
@@ -50,6 +52,8 @@ Interfacing with :py:class:`xarray.DataArray` and :py:class:`xarray.Dataset` cla
    to_cog
    write_cog
    compress
+   mask
+   crop
 
 
 odc.geo.geobox

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -37,6 +37,7 @@ from .overlap import compute_output_geobox
 from .types import Resolution, xy_
 
 # pylint: disable=import-outside-toplevel
+# pylint: disable=too-many-lines
 if have.rasterio:
     from ._cog import to_cog, write_cog
     from ._compress import compress
@@ -243,6 +244,96 @@ def assign_crs(
             band.encoding.update(grid_mapping=crs_coord_name)
 
     return xx
+
+
+def mask(xx: XrT, poly: Geometry, all_touched: bool = True) -> XrT:
+    """
+    Apply a polygon geometry as a mask, setting all xr.Dataset
+    or xr.DataArray pixels outside the rasterized polygon to ``NaN``.
+
+    :param xx:
+       :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray`.
+
+    :param poly:
+       Geometry shape used to mask ``xx``.
+
+    :param all_touched:
+        If ``True``, all pixels touched by ``poly`` will remain unmasked.
+        If ``False``, only pixels whose center is within the polygon or
+        that are selected by Bresenham's line algorithm will remain unmasked.
+
+    :return:
+        A :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray`
+        masked by ``poly``.
+    """
+
+    # Reproject `poly` to match `xx`
+    poly = poly.to_crs(crs=xx.odc.crs)
+
+    # Rasterise `poly` into geobox of `xx`
+    rasterized = rasterize(
+        poly=poly,
+        how=xx.odc.geobox,
+        all_touched=all_touched,
+    )
+
+    # Mask data outside rasterized `poly`
+    xx_masked = xx.where(rasterized.data)
+
+    return xx_masked
+
+
+def crop(
+    xx: XrT, poly: Geometry, apply_mask: bool = True, all_touched: bool = True
+) -> XrT:
+    """
+    Crops and optionally mask an xr.Dataset or xr.DataArray (``xx``) to
+    the spatial extent of a geometry (``poly``).
+
+    :param xx:
+       :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray`.
+
+    :param poly:
+       Geometry shape used to crop ``xx``.
+
+    :param apply_mask:
+       Whether to mask out pixels outside of the rasterized extent of
+       ``poly`` by setting them to ``NaN``.
+
+    :param all_touched:
+        If ``True``, all pixels touched by ``poly`` will remain unmasked.
+        If ``False``, only pixels whose center is within the polygon or
+        that are selected by Bresenham's line algorithm will remain unmasked.
+
+    :return:
+        A :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray`
+        cropped and optionally masked to the spatial extent of ``poly``.
+    """
+    # Reproject `poly` to match `xx`
+    poly = poly.to_crs(crs=xx.odc.crs)
+
+    # Verify that `poly` overlaps with `xx` extent
+    if not poly.intersects(xx.odc.geobox.extent):
+        raise ValueError(
+            "The supplied `poly` must overlap spatially with the extent of `xx`."
+        )
+
+    # Optionally mask data outside rasterized `poly`
+    if apply_mask:
+        xx = mask(xx, poly, all_touched=all_touched)
+
+    # Identify spatial dims and raise error if None
+    sdims = spatial_dims(xx)
+    if sdims is None:
+        raise ValueError("Can't locate spatial dimensions")
+
+    # Crop `xx` to the bounding box of `poly`. First create new geobox
+    # with the same pixel grid as `xx` but enclosing `poly`. Then
+    # calculate slices into `xx` for the intersection between both geoboxes.
+    roi = xx.odc.geobox.overlap_roi(xx.odc.geobox.enclosing(poly))
+    xx_cropped = xx.isel({sdims[0]: roi[0], sdims[1]: roi[1]})
+
+    return xx_cropped
 
 
 def xr_coords(
@@ -657,6 +748,13 @@ class ODCExtension:
         """Query :py:class:`~odc.geo.geobox.GeoBox` or :py:class:`~odc.geo.gcp.GCPGeoBox`."""
         return self._state.geobox
 
+    @property
+    def aspect(self) -> float:
+        gbox = self._state.geobox
+        if gbox is None:
+            return 1
+        return gbox.aspect
+
     def output_geobox(self, crs: SomeCRS, **kw) -> GeoBox:
         """
         Compute geobox of this data in other projection.
@@ -676,6 +774,9 @@ class ODCExtension:
             raise ValueError("Not geo registered")
 
         return gbox.map_bounds()
+
+    mask = _wrap_op(mask)
+    crop = _wrap_op(crop)
 
 
 @xarray.register_dataarray_accessor("odc")

--- a/odc/geo/xr.py
+++ b/odc/geo/xr.py
@@ -18,6 +18,8 @@ from ._xr_interop import (
     ODCExtensionDs,
     assign_crs,
     colorize,
+    crop,
+    mask,
     rasterize,
     register_geobox,
     spatial_dims,
@@ -45,6 +47,8 @@ __all__ = [
     "xr_zeros",
     "colorize",
     "to_rgba",
+    "crop",
+    "mask",
 ]
 
 # pylint: disable=import-outside-toplevel,unused-import


### PR DESCRIPTION
This PR introduces a new `.odc.crop` method that supports:

- Clipping an `xarray.Dataset` or `xr.DataArray` to the spatial extent of a datacube `Geometry` polygon
- Optionally apply the polygon as a mask by rasterizing it to the new geobox

![image](https://github.com/opendatacube/odc-geo/assets/17680388/56c14a22-d0be-4377-9e9e-131071ebfcb8)

This will be very useful for pixel drill workflows that regularly involve a sequence of loading data, cropping to a certain extent using `.sel()`, then rasterizing a polygon and applying it as a mask.

I've tested that this works on both datasets and data arrays, and have included a check that the polygon overlaps with the geobox extent. Would welcome any other feedback to make this more robust! 