### PR TITLE
Add new `.odc.explore()` method for automatically plotting raster data on an interactive map 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -22,6 +22,7 @@ Interfacing with :py:class:`xarray.DataArray` and :py:class:`xarray.Dataset` cla
    ODCExtension.map_bounds
    ODCExtension.crop
    ODCExtension.mask
+   ODCExtension.explore
 
    ODCExtensionDa
    ODCExtensionDa.assign_crs

--- a/odc/geo/_compress.py
+++ b/odc/geo/_compress.py
@@ -37,9 +37,13 @@ def _compress_image(im: np.ndarray, driver="PNG", **opts) -> bytes:
     if im.ndim == 3:
         h, w, nc = im.shape
         bands = np.transpose(im, axes=(2, 0, 1))  # Y,X,B -> B,Y,X
-    else:
+    elif im.ndim == 2:
         (h, w), nc = im.shape, 1
         bands = im.reshape(nc, h, w)
+    else:
+        raise ValueError(
+            f"Expected a 2 or 3 dimensional array; got {im.ndim} dimensions."
+        )
 
     rio_opts = {
         "width": w,

--- a/odc/geo/_rgba.py
+++ b/odc/geo/_rgba.py
@@ -105,7 +105,14 @@ def to_rgba(
     assert isinstance(ds, xr.Dataset)
 
     if bands is None:
-        bands = _guess_rgb_names(list(ds.data_vars))
+        try:
+            bands = _guess_rgb_names(list(ds.data_vars))
+        except ValueError as e:
+            raise ValueError(
+                f"Unable to automatically guess RGB colours ({e}). "
+                f"Manually specify red, green and blue bands using the "
+                f"`bands` parameter."
+            ) from e
 
     is_dask = is_dask_collection(ds)
     if vmin is None:
@@ -114,7 +121,7 @@ def to_rgba(
 
     if vmax is None:
         if is_dask:
-            raise ValueError("Must specify clamp for Dask inputs")
+            raise ValueError("Must specify clamp for Dask inputs (e.g. vmax, vmin)")
         _vmin, vmax = _auto_guess_clamp(ds[list(bands)])
         vmin = _vmin if vmin is None else vmin
 

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -43,7 +43,7 @@ from .types import Resolution, xy_
 if have.rasterio:
     from ._cog import to_cog, write_cog
     from ._compress import compress
-    from ._map import add_to
+    from ._map import add_to, explore
     from .warp import rio_reproject
 
 XarrayObject = Union[xarray.DataArray, xarray.Dataset]
@@ -252,8 +252,9 @@ def mask(
     xx: XrT, poly: Geometry, invert: bool = False, all_touched: bool = True
 ) -> XrT:
     """
-    Apply a polygon geometry as a mask, setting all xr.Dataset
-    or xr.DataArray pixels outside the rasterized polygon to ``NaN``.
+    Apply a polygon geometry as a mask, setting all
+    :py:class:`xarray.Dataset` or :py:class:`xarray.DataArray` pixels
+    outside the rasterized polygon to ``NaN``.
 
     :param xx:
        :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray`.
@@ -302,8 +303,8 @@ def crop(
     xx: XrT, poly: Geometry, apply_mask: bool = True, all_touched: bool = True
 ) -> XrT:
     """
-    Crops and optionally mask an xr.Dataset or xr.DataArray to the
-    spatial extent of a geometry.
+    Crops and optionally mask an :py:class:`xarray.Dataset` or
+    :py:class:`xarray.DataArray` to the spatial extent of a geometry.
 
     :param xx:
        :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray`.
@@ -794,6 +795,9 @@ class ODCExtension:
 
     mask = _wrap_op(mask)
     crop = _wrap_op(crop)
+
+    if have.rasterio:
+        explore = _wrap_op(explore)
 
 
 @xarray.register_dataarray_accessor("odc")

--- a/odc/geo/xr.py
+++ b/odc/geo/xr.py
@@ -53,7 +53,7 @@ __all__ = [
 
 # pylint: disable=import-outside-toplevel,unused-import
 if have.rasterio:
-    from ._xr_interop import add_to, compress, rio_reproject, to_cog, write_cog
+    from ._xr_interop import add_to, compress, rio_reproject, to_cog, write_cog, explore
 
     __all__.extend(
         [
@@ -62,5 +62,6 @@ if have.rasterio:
             "add_to",
             "rio_reproject",
             "compress",
+            "explore",
         ]
     )


### PR DESCRIPTION
This PR addresses #104 by adding a new `.explore()` method for automatically plotting raster data into an interactive map. This is designed to replicate the extremely useful `.explore()` method from Geopandas: https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.explore.html

Essentially `explore` combines `to_rgba` and `add_to` from this repo into a single easy to use method.

Supports single band `xr.DataArray` inputs:
![image](https://github.com/opendatacube/odc-geo/assets/17680388/28513cc7-7bfb-421b-9e28-9758bfc00d97)

Automatically converts `xr.Dataset` inputs to RGB:
![image](https://github.com/opendatacube/odc-geo/assets/17680388/73c62df6-9c11-49d2-ae76-c507b6eca5d0)

And easily passing in custom mapping params like basemaps:
![image](https://github.com/opendatacube/odc-geo/assets/17680388/7a49a962-0245-4b0e-bde4-a505ed67b566)
