### PR TITLE
Unify reproject behaviour on Dataset and DataArray

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -306,7 +306,7 @@ jobs:
       - name: Deploy to Netlify
         id: netlify
         if: github.event_name == 'pull_request'
-        uses: nwtgck/actions-netlify@v1.2
+        uses: nwtgck/actions-netlify@v2
         with:
           production-branch: "main"
           publish-dir: "docs/_build/html"

--- a/docs/api-geobox.rst
+++ b/docs/api-geobox.rst
@@ -6,7 +6,6 @@ GeoBox
    :toctree: _api/
 
    GeoBox
-   AnchorEnum
    GeoBox.from_geopolygon
    GeoBox.from_bbox
    GeoBox.affine

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -175,6 +175,7 @@ Basic types used for unambigous specification of X/Y values.
    Resolution
    Shape2d
    Index2d
+   AnchorEnum
 
    xy_
    yx_

--- a/odc/geo/__init__.py
+++ b/odc/geo/__init__.py
@@ -11,6 +11,7 @@
 from ._version import __version__
 
 from .types import (
+    AnchorEnum,
     XY,
     Index2d,
     Shape2d,
@@ -46,6 +47,7 @@ from .geom import (
 
 __all__ = [
     "__version__",
+    "AnchorEnum",
     "XY",
     "Index2d",
     "Shape2d",

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -594,6 +594,23 @@ def xr_reproject(
     """
     Reproject raster to different projection/resolution.
 
+    :param src:
+      :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray` to reproject.
+
+    :param how:
+      How to reproject the raster. Can be a GeoBox or a CRS (e.g. CRS object or
+      an "ESPG:XXXX" string/integer). If a CRS is provided, the output pixel
+      grid can be customised further via ``resolution``, ``shape``, ``tight``,
+      ``anchor``, ``tol``, ``round_resolution``.
+
+    :param resampling:
+      Resampling method to use when reprojecting the raster. Defaults to
+      "nearest", also supports "average", "bilinear", "cubic", "cubic_spline",
+      "lanczos", "mode", "gauss", "max", "min", "med", "q1", "q3".
+
+    :param dst_nodata:
+      Set a custom nodata value for the output resampled raster.
+
     :param resolution:
 
        * "same" use exactly the same resolution as src

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -275,7 +275,7 @@ def mask(
         A :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray`
         masked by ``poly``.
 
-    ..seealso:: :py:meth:`odc.geo.xr.rasterize`
+    .. seealso:: :py:meth:`odc.geo.xr.rasterize`
     """
     # Rasterise `poly` into geobox of `xx`
     rasterized = rasterize(
@@ -325,7 +325,7 @@ def crop(
         A :py:class:`~xarray.Dataset` or :py:class:`~xarray.DataArray`
         cropped and optionally masked to the spatial extent of ``poly``.
 
-    ..seealso:: :py:meth:`odc.geo.xr.mask`
+    .. seealso:: :py:meth:`odc.geo.xr.mask`
     """
     # Create new geobox with pixel grid of `xx` but enclosing `poly`.
     poly_geobox = xx.odc.geobox.enclosing(poly)
@@ -589,9 +589,7 @@ def xr_reproject(
 
     This method uses :py:mod:`rasterio`.
 
-    ..seealso::
-
-       :py:meth:`odc.geo.overlap.compute_output_geobox`
+    .. seealso:: :py:meth:`odc.geo.overlap.compute_output_geobox`
 
     """
     if isinstance(src, xarray.DataArray):
@@ -791,7 +789,7 @@ class ODCExtension:
         """
         Compute geobox of this data in other projection.
 
-        ..seealso:: :py:meth:`odc.geo.overlap.compute_output_geobox`
+        .. seealso:: :py:meth:`odc.geo.overlap.compute_output_geobox`
         """
         gbox = self.geobox
         if gbox is None:

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -36,7 +36,7 @@ from .geom import Geometry
 from .math import affine_from_axis, maybe_int, resolution_from_affine
 from .overlap import compute_output_geobox
 from .roi import roi_is_empty
-from .types import AnchorEnum, Resolution, SomeResolution, SomeShape, xy_
+from .types import Resolution, SomeResolution, SomeShape, xy_
 
 # pylint: disable=import-outside-toplevel
 # pylint: disable=too-many-lines
@@ -586,7 +586,7 @@ def xr_reproject(
     resolution: Union[SomeResolution, Literal["auto", "fit", "same"]] = "auto",
     shape: Union[SomeShape, int, None] = None,
     tight: bool = False,
-    anchor: GeoboxAnchor = AnchorEnum.EDGE,
+    anchor: GeoboxAnchor = "default",
     tol: float = 0.01,
     round_resolution: Union[None, bool, Callable[[float, str], float]] = None,
     **kw,

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -64,10 +64,38 @@ from .types import (
     xy_,
 )
 
-GeoboxAnchor = Union[AnchorEnum, XY[float]]
+GeoboxAnchor = Union[
+    AnchorEnum,
+    XY[float],
+    float,
+    Literal["center"],
+    Literal["centre"],
+    Literal["edge"],
+    Literal["floating"],
+]
 
 # pylint: disable=invalid-name,too-many-public-methods,too-many-lines
 Coordinate = namedtuple("Coordinate", ("values", "units", "resolution"))
+
+
+def _norm_anchor(anchor: GeoboxAnchor) -> Union[AnchorEnum, XY[float]]:
+    if isinstance(anchor, AnchorEnum):
+        return anchor
+    if isinstance(anchor, (float, int)):
+        if anchor == 0:
+            return AnchorEnum.EDGE
+        if anchor == 0.5:
+            return AnchorEnum.CENTER
+        return xy_(float(anchor), float(anchor))
+    if isinstance(anchor, XY):
+        return anchor
+
+    return {
+        "center": AnchorEnum.CENTER,
+        "centre": AnchorEnum.CENTER,
+        "edge": AnchorEnum.EDGE,
+        "floating": AnchorEnum.FLOATING,
+    }[anchor]
 
 
 class GeoBoxBase:
@@ -444,6 +472,7 @@ class GeoBox(GeoBoxBase):
         """
         # pylint: disable=too-many-locals, too-many-branches
 
+        anchor = _norm_anchor(anchor)
         _snap: Optional[XY[float]] = None
 
         if tight:

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -72,6 +72,7 @@ GeoboxAnchor = Union[
     Literal["centre"],
     Literal["edge"],
     Literal["floating"],
+    Literal["default"],
 ]
 
 # pylint: disable=invalid-name,too-many-public-methods,too-many-lines
@@ -95,6 +96,7 @@ def _norm_anchor(anchor: GeoboxAnchor) -> Union[AnchorEnum, XY[float]]:
         "centre": AnchorEnum.CENTER,
         "edge": AnchorEnum.EDGE,
         "floating": AnchorEnum.FLOATING,
+        "default": AnchorEnum.EDGE,
     }[anchor]
 
 
@@ -447,7 +449,7 @@ class GeoBox(GeoBoxBase):
         tight: bool = False,
         shape: Union[SomeShape, int, None] = None,
         resolution: Optional[SomeResolution] = None,
-        anchor: GeoboxAnchor = AnchorEnum.EDGE,
+        anchor: GeoboxAnchor = "default",
         tol: float = 0.01,
     ) -> "GeoBox":
         """
@@ -544,7 +546,7 @@ class GeoBox(GeoBoxBase):
         *,
         shape: Union[SomeShape, int, None] = None,
         tight: bool = False,
-        anchor: GeoboxAnchor = AnchorEnum.EDGE,
+        anchor: GeoboxAnchor = "default",
         tol: float = 0.01,
     ) -> "GeoBox":
         """
@@ -748,7 +750,7 @@ class GeoBox(GeoBoxBase):
         resolution: Literal["auto", "fit", "same"] = "auto",
         shape: Union[SomeShape, int, None] = None,
         tight: bool = False,
-        anchor: GeoboxAnchor = AnchorEnum.EDGE,
+        anchor: GeoboxAnchor = "default",
         tol: float = 0.01,
         round_resolution: Union[None, bool, Callable[[float, str], float]] = None,
     ) -> "GeoBox":

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -717,7 +717,10 @@ class GeoBox(GeoBoxBase):
         crs: SomeCRS,
         *,
         resolution: Literal["auto", "fit", "same"] = "auto",
+        shape: Union[SomeShape, int, None] = None,
         tight: bool = False,
+        anchor: GeoboxAnchor = AnchorEnum.EDGE,
+        tol: float = 0.01,
         round_resolution: Union[None, bool, Callable[[float, str], float]] = None,
     ) -> "GeoBox":
         """
@@ -733,15 +736,32 @@ class GeoBox(GeoBoxBase):
            * | "auto" is to use the same resolution on the output if CRS units are the same
              |  between the source and destination and otherwise use "fit"
 
+        :param shape:
+          Span that many pixels, if it's a single number then span that many pixels
+          along the longest dimension, other dimension will be computed to maintain
+          roughly square pixels. Takes precedence over ``resolution=`` parameter.
+
         :param tight:
-          By default output pixel grid is adjusted to align pixel edges to X/Y axis, suppling
-          ``tight=True`` produces unaligned geobox on the output.
+          By default output pixel grid is adjusted to align pixel edges to X/Y
+          axis, suppling ``tight=True`` produces unaligned geobox on the output.
+
+        :param anchor:
+            Control pixel snapping, default is to snap pixel edge to
+            ``X=0,Y=0``. Ignored when ``tight=True`` is supplied.
+
+        :param tol:
+            Fraction of the output pixel that can be ignored, defaults to 1/100.
+            Bounding box of the output geobox is allowed to be smaller by that
+            amount than transformed footprint of the original.
+
+        :param round_resolution:
+          ``round_resolution(res: float, units: str) -> float``
 
         :return:
-           Similar resolution, axis aligned geobox that fully encloses this one but in a different
-           projection.
+           Similar resolution, axis aligned geobox that fully encloses this one
+           but in a different projection.
         """
-        # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-outside-toplevel,too-many-arguments
         # can't be up-top due to circular imports issues
         from .overlap import compute_output_geobox
 
@@ -749,8 +769,11 @@ class GeoBox(GeoBoxBase):
             self,
             crs,
             resolution=resolution,
+            shape=shape,
             tight=tight,
+            anchor=anchor,
             round_resolution=round_resolution,
+            tol=tol,
         )
 
     def __str__(self):

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -6,7 +6,6 @@ import importlib
 import itertools
 import math
 from collections import OrderedDict, namedtuple
-from enum import Enum
 from typing import (
     Callable,
     Dict,
@@ -48,6 +47,7 @@ from .roi import (
 from .types import (
     ROI,
     XY,
+    AnchorEnum,
     Chunks2d,
     MaybeInt,
     NormalizedROI,
@@ -63,22 +63,6 @@ from .types import (
     shape_,
     xy_,
 )
-
-
-class AnchorEnum(Enum):
-    """
-    Defines which way to snap geobox pixel grid.
-    """
-
-    EDGE = 0
-    """Snap pixel edges to multiples of pixel size."""
-
-    CENTER = 1
-    """Snap pixel centers to multiples of pixel size."""
-
-    FLOATING = 2
-    """Turn off pixel snapping."""
-
 
 GeoboxAnchor = Union[AnchorEnum, XY[float]]
 

--- a/odc/geo/overlap.py
+++ b/odc/geo/overlap.py
@@ -31,7 +31,7 @@ from .roi import (
     roi_is_empty,
     scaled_up_roi,
 )
-from .types import XY, AnchorEnum, SomeResolution, SomeShape, res_, shape_, xy_
+from .types import XY, SomeResolution, SomeShape, res_, shape_, xy_
 
 
 class PointTransform(Protocol):
@@ -565,7 +565,7 @@ def compute_output_geobox(
     resolution: Union[SomeResolution, Literal["auto", "fit", "same"]] = "auto",
     shape: Union[SomeShape, int, None] = None,
     tight: bool = False,
-    anchor: GeoboxAnchor = AnchorEnum.EDGE,
+    anchor: GeoboxAnchor = "default",
     tol: float = 0.01,
     round_resolution: Union[None, bool, Callable[[float, str], float]] = None,
 ) -> GeoBox:
@@ -619,6 +619,7 @@ def compute_output_geobox(
     src_crs = gbox.crs
     assert src_crs is not None
 
+    # figure out "true" dts_crs (handles "utm" -> actual CRS)
     bbox = gbox.footprint(crs, buffer=0.9, npoints=100).boundingbox
     dst_crs = bbox.crs
     assert dst_crs is not None
@@ -626,6 +627,8 @@ def compute_output_geobox(
     if (
         dst_crs == src_crs
         and resolution in ("auto", "same")
+        and shape is None
+        and anchor == "default"
         and isinstance(gbox, GeoBox)
     ):
         return gbox

--- a/odc/geo/types.py
+++ b/odc/geo/types.py
@@ -1,4 +1,5 @@
 """Basic types."""
+from enum import Enum
 from typing import (
     Callable,
     Generic,
@@ -456,6 +457,21 @@ NormalizedROI = Tuple[NormalizedSlice, NormalizedSlice]
 OutlineMode = Union[
     Literal["native"], Literal["pixel"], Literal["geo"], Literal["auto"]
 ]
+
+
+class AnchorEnum(Enum):
+    """
+    Defines which way to snap geobox pixel grid.
+    """
+
+    EDGE = 0
+    """Snap pixel edges to multiples of pixel size."""
+
+    CENTER = 1
+    """Snap pixel centers to multiples of pixel size."""
+
+    FLOATING = 2
+    """Turn off pixel snapping."""
 
 
 class _Func2Map(Mapping[TK, TV]):

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -413,12 +413,44 @@ def test_from_bbox():
     ) == GeoBox.from_bbox(bbox, shape=shape, tight=True)
 
     assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.FLOATING
+    ) == GeoBox.from_bbox(bbox, shape=shape, anchor="floating")
+
+    assert GeoBox.from_bbox(
         bbox, shape=shape, anchor=AnchorEnum.EDGE
     ) == GeoBox.from_bbox(bbox, shape=shape, anchor=xy_(0, 0))
 
     assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.EDGE
+    ) != GeoBox.from_bbox(bbox, shape=shape, anchor=xy_(0.3, 0))
+
+    assert GeoBox.from_bbox(bbox, shape=shape, anchor=0.3) == GeoBox.from_bbox(
+        bbox, shape=shape, anchor=xy_(0.3, 0.3)
+    )
+
+    assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.EDGE
+    ) == GeoBox.from_bbox(bbox, shape=shape, anchor=0)
+
+    assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.EDGE
+    ) == GeoBox.from_bbox(bbox, shape=shape)
+
+    assert GeoBox.from_bbox(
         bbox, shape=shape, anchor=AnchorEnum.CENTER
     ) == GeoBox.from_bbox(bbox, shape=shape, anchor=xy_(0.5, 0.5))
+
+    assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.CENTER
+    ) == GeoBox.from_bbox(bbox, shape=shape, anchor=0.5)
+
+    assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.CENTER
+    ) == GeoBox.from_bbox(bbox, shape=shape, anchor="center")
+
+    assert GeoBox.from_bbox(
+        bbox, shape=shape, anchor=AnchorEnum.CENTER
+    ) == GeoBox.from_bbox(bbox, shape=shape, anchor="centre")
 
     assert GeoBox.from_bbox((1, 40, 2, 43), "utm", shape=(12, 12)).crs == "epsg:32631"
 

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 from affine import Affine
 
-from odc.geo import CRS, geom, res_, resyx_, wh_, xy_
+from odc.geo import CRS, AnchorEnum, geom, res_, resyx_, wh_, xy_
 from odc.geo.geobox import GeoBox, scaled_down_geobox
 from odc.geo.gridspec import GridSpec
 from odc.geo.math import affine_from_pts, decompose_rws, is_affine_st, stack_xy
@@ -486,6 +486,15 @@ def test_compute_output_geobox():
     assert dst.geographic_extent.contains(src.geographic_extent)
     npix_change = (src.shape[0] * src.shape[1]) / (dst.shape[0] * dst.shape[1])
     assert 0.8 < npix_change < 1.1
+
+    # check anchor= having effect
+    assert compute_output_geobox(
+        src, 4326, anchor=AnchorEnum.CENTER
+    ) != compute_output_geobox(src, 4326, anchor=AnchorEnum.EDGE)
+
+    # check shape= having effect
+    assert compute_output_geobox(src, 4326, shape=(10, 20)).shape == (10, 20)
+    assert max(compute_output_geobox(src, 4326, shape=100, tight=True).shape) == 100
 
     # go back from 4326
     _src = dst


### PR DESCRIPTION
Expose all the possible `GeoBox.from_bbox` parameters on `.reproject`, `.output_geobox`,  `.to_crs`

- Closes #122