### PR TITLE
Add `.explore()` to GeoBox, Geometry, BoundingBox

### DIFF
--- a/docs/api-geobox.rst
+++ b/docs/api-geobox.rst
@@ -18,6 +18,7 @@ GeoBox
    GeoBox.flipx
    GeoBox.flipy
    GeoBox.extent
+   GeoBox.explore
    GeoBox.footprint
    GeoBox.boundingbox
    GeoBox.map_bounds

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -116,7 +116,9 @@ Shapely geometry classes with CRS information attached.
    Geometry
    Geometry.to_crs
    Geometry.geojson
+   Geometry.explore
    BoundingBox
+   BoundingBox.explore
    BoundingBox.from_xy
    BoundingBox.from_points
    BoundingBox.from_transform

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,7 @@ intersphinx_mapping = {
     "xr": ("https://xarray.pydata.org/en/stable/", None),
     "rasterio": ("https://rasterio.readthedocs.io/en/latest/", None),
     "shapely": ("https://shapely.readthedocs.io/en/latest/", None),
+    "folium": ("https://python-visualization.github.io/folium/latest/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/odc/geo/_map.py
+++ b/odc/geo/_map.py
@@ -231,7 +231,7 @@ def explore(
         Custom resampling method to use when reprojecting ``xx`` to the
         map CRS; defaults to "nearest".
     :param map_kwds:
-        Additional keyword arguments to pass to ``folium.Map()``.
+        Additional keyword arguments to pass to :py:class:`folium.Map`.
     :param kwargs:
         Additional keyword arguments to pass to ``.odc.add_to()``.
 

--- a/odc/geo/_map.py
+++ b/odc/geo/_map.py
@@ -170,7 +170,6 @@ def add_to(
     return _add_to(url, bounds, map, name=name, **kw)
 
 
-# pylint: disable=too-many-arguments, protected-access, anomalous-backslash-in-string
 def explore(
     xx: Any,
     map: Optional[Any] = None,
@@ -233,11 +232,13 @@ def explore(
         map CRS; defaults to "nearest".
     :param map_kwds:
         Additional keyword arguments to pass to ``folium.Map()``.
-    :param \**kwargs:
+    :param kwargs:
         Additional keyword arguments to pass to ``.odc.add_to()``.
 
     :return: A :py:mod:`folium` map containing the plotted xarray data.
     """
+    # pylint: disable=too-many-arguments, protected-access
+
     if not have.folium:
         raise ModuleNotFoundError(
             "'folium' is required but not installed. "

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -7,6 +7,7 @@ import itertools
 import math
 from collections import OrderedDict, namedtuple
 from typing import (
+    Any,
     Callable,
     Dict,
     Iterator,
@@ -421,6 +422,54 @@ class GeoBoxBase:
         return BoundingBox(0, 0, nx, ny, None).qr2sample(
             n, padding=padding, with_edges=with_edges, offset=offset
         )
+
+    def explore(
+        self,
+        map: Optional[Any] = None,
+        grid_lines: bool = True,
+        tiles: Any = "OpenStreetMap",
+        attr: Optional[str] = None,
+        map_kwds: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """
+        Plot a visual representation of the GeoBox's extent on an
+        interactive :py:mod:`folium` leaflet map.
+
+        :param map:
+            An optional existing :py:mod:`folium` map object to plot into.
+            By default, a new map object will be created.
+        :param: grid_lines:
+            Whether to plot pixel edge aligned grid lines over the GeoBox
+            extent.
+        :param tiles:
+            Map tileset to use for the map basemap. Supports any option
+            supported by :py:mod:`folium`, including "OpenStreetMap",
+            "CartoDB positron", "CartoDB dark_matter" or a custom XYZ URL.
+        :param attr:
+            Map tile attribution; only required if passing custom tile URL.
+        :param map_kwds:
+            Additional keyword arguments to pass to ``folium.Map()``.
+        :param \**kwargs:
+            Additional keyword arguments to pass to ``folium.GeoJson``.
+
+        :return: A :py:mod:`folium` map containing the plotted GeoBox.
+        """
+        # Add outline to map
+        map = self.outline(mode="geo", notch=0.0).explore(
+            map=map, tiles=tiles, attr=attr, map_kwds=map_kwds, **kwargs
+        )
+
+        # Optionally overlay grid lines
+        if grid_lines:
+            self.grid_lines(mode="geo").explore(
+                map=map,
+                style_function=lambda feature: {
+                    "weight": 1,
+                    "fillOpacity": 0.3,
+                },
+            )
+        return map
 
     def __getitem__(self, roi) -> "GeoBoxBase":
         raise NotImplementedError()

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -423,7 +423,6 @@ class GeoBoxBase:
             n, padding=padding, with_edges=with_edges, offset=offset
         )
 
-    # pylint: disable=redefined-builtin, anomalous-backslash-in-string
     def explore(
         self,
         map: Optional[Any] = None,
@@ -451,11 +450,13 @@ class GeoBoxBase:
             Map tile attribution; only required if passing custom tile URL.
         :param map_kwds:
             Additional keyword arguments to pass to ``folium.Map()``.
-        :param \**kwargs:
+        :param kwargs:
             Additional keyword arguments to pass to ``folium.GeoJson``.
 
         :return: A :py:mod:`folium` map containing the plotted GeoBox.
         """
+        # pylint: disable=redefined-builtin
+
         # Add outline to map
         map = self.outline(mode="geo", notch=0.0).explore(
             map=map, tiles=tiles, attr=attr, map_kwds=map_kwds, **kwargs

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -456,15 +456,17 @@ class GeoBoxBase:
 
         :return: A :py:mod:`folium` map containing the plotted GeoBox.
         """
-        # Add outline to map
+        # Add outline to map. No need for additional densification as
+        # `.outline` and `.grid_lines` already perform this
         map = self.outline(mode="geo", notch=0.0).explore(
-            map=map, tiles=tiles, attr=attr, map_kwds=map_kwds, **kwargs
+            map=map, densify=False, tiles=tiles, attr=attr, map_kwds=map_kwds, **kwargs
         )
 
         # Optionally overlay grid lines
         if grid_lines:
             self.grid_lines(mode="geo").explore(
                 map=map,
+                densify=False,
                 style_function=lambda feature: {
                     "weight": 1,
                     "fillOpacity": 0.3,

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -456,17 +456,15 @@ class GeoBoxBase:
 
         :return: A :py:mod:`folium` map containing the plotted GeoBox.
         """
-        # Add outline to map. No need for additional densification as
-        # `.outline` and `.grid_lines` already perform this
+        # Add outline to map
         map = self.outline(mode="geo", notch=0.0).explore(
-            map=map, densify=False, tiles=tiles, attr=attr, map_kwds=map_kwds, **kwargs
+            map=map, tiles=tiles, attr=attr, map_kwds=map_kwds, **kwargs
         )
 
         # Optionally overlay grid lines
         if grid_lines:
             self.grid_lines(mode="geo").explore(
                 map=map,
-                densify=False,
                 style_function=lambda feature: {
                     "weight": 1,
                     "fillOpacity": 0.3,

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -449,7 +449,7 @@ class GeoBoxBase:
         :param attr:
             Map tile attribution; only required if passing custom tile URL.
         :param map_kwds:
-            Additional keyword arguments to pass to ``folium.Map()``.
+            Additional keyword arguments to pass to :py:class:`folium.Map`.
         :param kwargs:
             Additional keyword arguments to pass to :py:class:`folium.GeoJson`.
 

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -451,7 +451,7 @@ class GeoBoxBase:
         :param map_kwds:
             Additional keyword arguments to pass to ``folium.Map()``.
         :param kwargs:
-            Additional keyword arguments to pass to ``folium.GeoJson``.
+            Additional keyword arguments to pass to :py:class:`folium.GeoJson`.
 
         :return: A :py:mod:`folium` map containing the plotted GeoBox.
         """

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -423,6 +423,7 @@ class GeoBoxBase:
             n, padding=padding, with_edges=with_edges, offset=offset
         )
 
+    # pylint: disable=redefined-builtin, anomalous-backslash-in-string
     def explore(
         self,
         map: Optional[Any] = None,

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -203,7 +203,6 @@ class BoundingBox(Sequence[float]):
         (x0, y0), _, (x1, y1) = self.polygon.exterior.to_crs("epsg:4326").points[:3]
         return (y0, x0), (y1, x1)
 
-    # pylint: disable=redefined-builtin, anomalous-backslash-in-string
     def explore(
         self,
         map: Optional[Any] = None,
@@ -227,11 +226,12 @@ class BoundingBox(Sequence[float]):
             Map tile attribution; only required if passing custom tile URL.
         :param map_kwds:
             Additional keyword arguments to pass to ``folium.Map()``.
-        :param \**kwargs:
+        :param kwargs:
             Additional keyword arguments to pass to ``folium.GeoJson``.
 
         :return: A :py:mod:`folium` map containing the plotted BoundingBox.
         """
+        # pylint: disable=redefined-builtin
         return self.polygon.explore(
             map=map,
             tiles=tiles,
@@ -813,7 +813,6 @@ class Geometry(SupportsCoords[float]):
         for g in ops.split(self.geom, splitter.geom).geoms:
             yield Geometry(g, self.crs)
 
-    # pylint: disable=import-outside-toplevel, redefined-builtin, anomalous-backslash-in-string
     def explore(
         self,
         map: Optional[Any] = None,
@@ -837,11 +836,13 @@ class Geometry(SupportsCoords[float]):
             Map tile attribution; only required if passing custom tile URL.
         :param map_kwds:
             Additional keyword arguments to pass to ``folium.Map()``.
-        :param \**kwargs:
+        :param kwargs:
             Additional keyword arguments to pass to ``folium.GeoJson``.
 
         :return: A :py:mod:`folium` map containing the plotted Geometry.
         """
+        # pylint: disable=import-outside-toplevel, redefined-builtin
+
         if not have.folium:
             raise ModuleNotFoundError(
                 "'folium' is required but not installed. "

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -203,6 +203,7 @@ class BoundingBox(Sequence[float]):
         (x0, y0), _, (x1, y1) = self.polygon.exterior.to_crs("epsg:4326").points[:3]
         return (y0, x0), (y1, x1)
 
+    # pylint: disable=redefined-builtin, anomalous-backslash-in-string
     def explore(
         self,
         map: Optional[Any] = None,
@@ -808,6 +809,7 @@ class Geometry(SupportsCoords[float]):
         for g in ops.split(self.geom, splitter.geom).geoms:
             yield Geometry(g, self.crs)
 
+    # pylint: disable=import-outside-toplevel, redefined-builtin, anomalous-backslash-in-string
     def explore(
         self,
         map: Optional[Any] = None,

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -225,9 +225,9 @@ class BoundingBox(Sequence[float]):
         :param attr:
             Map tile attribution; only required if passing custom tile URL.
         :param map_kwds:
-            Additional keyword arguments to pass to ``folium.Map()``.
+            Additional keyword arguments to pass to :py:class:`folium.Map`.
         :param kwargs:
-            Additional keyword arguments to pass to ``folium.GeoJson``.
+            Additional keyword arguments to pass to :py:class:`folium.GeoJson`.
 
         :return: A :py:mod:`folium` map containing the plotted BoundingBox.
         """
@@ -835,9 +835,9 @@ class Geometry(SupportsCoords[float]):
         :param attr:
             Map tile attribution; only required if passing custom tile URL.
         :param map_kwds:
-            Additional keyword arguments to pass to ``folium.Map()``.
+            Additional keyword arguments to pass to :py:class:`folium.Map`.
         :param kwargs:
-            Additional keyword arguments to pass to ``folium.GeoJson``.
+            Additional keyword arguments to pass to :py:class:`folium.GeoJson`.
 
         :return: A :py:mod:`folium` map containing the plotted Geometry.
         """

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -65,7 +65,7 @@ def test_add_to_ipyleaflet(ocean_raster: xr.DataArray):
 
 
 @pytest.mark.skipif(have.folium is False, reason="No folium installed")
-def test_explore(ocean_raster: xr.DataArray, ocean_raster_ds: xr.Dataset):
+def test_explore_xr(ocean_raster: xr.DataArray, ocean_raster_ds: xr.Dataset):
     import folium
     from folium.raster_layers import ImageOverlay
 


### PR DESCRIPTION
This PR addresses #125 by adding `.explore()` methods for interactively plotting `Geometry`, `BoundingBox` and `GeoBox` objects on a Folium map.

This matches the recently added (#104) `.odc.explore()` functionality for exploring `xarray` data, and the existing `.explore()` functionality from `GeoPandas`. It is intended to allow users to:
- Easily verify that the extents/shape of their geometries line up with their expected AOI
- Bugfix issues when creating complex Geometries
- Visually communicate to beginner users where they are about to load or analyse data

GeoPolygon (no issues with complex geometries including MultiPolygons):
![image](https://github.com/opendatacube/odc-geo/assets/17680388/afe6d01f-0505-450f-92cc-3c358ffa1ba0)

GeoBox (plots data from the existing `.outline` and `.grid_lines` methods):
![image](https://github.com/opendatacube/odc-geo/assets/17680388/138e3dee-6fb0-4cdf-b39f-5e1100b73310)

BoundingBox:
![image](https://github.com/opendatacube/odc-geo/assets/17680388/776d9bc5-170f-4b7d-9423-194c83bbd78f)

Have used the inbuilt `resolution` functionality of the `.geojson()` method to densify features prior to plotting to ensure they are represented correctly on the map (following the UI example here: https://github.com/opendatacube/odc-geo/blob/develop/odc/geo/ui.py#L295-L297).

