### PR TITLE
Disallow zero and negative size shapes

### DIFF
--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -122,6 +122,11 @@ class GeoBoxBase:
         self._extent: Optional[Geometry] = None
         self._lazy_ui = None
 
+        if self.shape.x < 0 or self.shape.y < 0:
+            raise ValueError(
+                f"Got shape {self._shape.yx!r}: negative sizes are not allowed."
+            )
+
     @property
     def width(self) -> int:
         """Width in pixels (nx)."""
@@ -576,6 +581,17 @@ class GeoBox(GeoBoxBase):
 
         shape = shape_(shape)
         nx, ny = shape.wh
+
+        if nx == 0 or ny == 0:
+            raise ValueError(
+                f"Got zero size in ({nx}, {ny}): cannot calculate resolution."
+            )
+
+        if nx < 0 or ny < 0:
+            raise ValueError(
+                f"Got negative size in ({nx}, {ny}): negative dimensions are not allowed."
+            )
+
         rx = bbox.span_x / nx
         ry = -bbox.span_y / ny
 

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -685,3 +685,22 @@ def test_explore_geobox(geobox):
     assert (
         sum(isinstance(child, GeoJson) for child in m_external._children.values()) == 2
     )
+
+
+@pytest.mark.parametrize(
+    ("shape", "allowed"),
+    [
+        pytest.param((100, 100), True, id="positive xy: normal"),
+        pytest.param((0, 100), False, id="zero x: can't calculate resolution"),
+        pytest.param((100, 0), False, id="zero y: can't calculate resolution"),
+        pytest.param((-100, 100), False, id="negative x: not allowed"),
+        pytest.param((100, -100), False, id="negative y: not allowed"),
+        pytest.param((-100, -100), False, id="both negative: not allowed"),
+    ],
+)
+def test_shape(shape, allowed):
+    if allowed:
+        GeoBox.from_bbox((-3, -4, 3, 4), epsg4326, shape=shape)
+    else:
+        with pytest.raises(ValueError):
+            GeoBox.from_bbox((-3, -4, 3, 4), epsg4326, shape=shape)


### PR DESCRIPTION
Attempting to create a GeoBox with an x or y dimension of zero results in a zero-division error because it's not possible to calculate the resolution of the box.  Attempting to create a GeoBox with a negative dimension works but flips the transform.  That's confusing so we'd like to disallow it.

This PR raises exceptions when these situations occur; I've also added tests to confirm functionality.

Resolves #136.