### PR TITLE
Bump codecov-action version to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,7 +218,7 @@ jobs:
         if: |
           github.repository == 'opendatacube/odc-geo'
 
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: false


### PR DESCRIPTION
This takes care of the CI warning:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```