### PR TITLE
Write band descriptions in save_cog_with_dask

### DIFF
--- a/odc/geo/cog/_tifffile.py
+++ b/odc/geo/cog/_tifffile.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 
 def _render_gdal_metadata(
-    band_stats: list[dict[str, float]] | dict[str, float],
+    band_stats: list[dict[str, float]] | dict[str, float] | None,
     precision: int = 10,
     pad: int = 0,
     eol: str = "",
@@ -54,6 +54,8 @@ def _render_gdal_metadata(
             ]
         )
 
+    if band_stats is None:
+        band_stats = []
     if isinstance(band_stats, dict):
         band_stats = [band_stats]
 

--- a/odc/geo/cog/_tifffile.py
+++ b/odc/geo/cog/_tifffile.py
@@ -487,7 +487,7 @@ def _patch_hdr(
     _bio = BytesIO(hdr0)
     with TiffFile(_bio, mode="r+", name=":mem:") as tr:
         assert len(tile_info) == len(tr.pages)
-        if stats is not None:
+        if stats is not None or gdal_metadata_extra:
             md_tag = tr.pages.first.tags.get(42112, None)
             assert md_tag is not None
             gdal_metadata = _render_gdal_metadata(
@@ -600,7 +600,7 @@ def _gdal_sample_description(sample: int, description: str) -> str:
 def _gdal_sample_descriptions(xx: xr.DataArray) -> List[str]:
     """Translate ``long_name`` attribute (if present) to GDAL sample description metadata.
 
-    :param xx: Pixels as :py:class:`xarray.DataArray` backed by Dask
+    :param xx: Pixels as :py:class:`xarray.DataArray`
 
     :return: List of GDAL XML metadata lines to place in TIFF file.
     """

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -336,11 +336,31 @@ def test_geotiff_metadata(gbox: GeoBox, nodata, gdal_metadata: Optional[str]):
 @pytest.mark.parametrize(
     ("sample", "description", "expected"),
     [
-        (0, "easy", '<Item name="DESCRIPTION" sample="0" role="description">easy</Item>'),
-        (1, "<", '<Item name="DESCRIPTION" sample="1" role="description">&amp;lt;</Item>'),
-        (2, ">", '<Item name="DESCRIPTION" sample="2" role="description">&amp;gt;</Item>'),
-        (3, "&", '<Item name="DESCRIPTION" sample="3" role="description">&amp;amp;</Item>'),
-        (4, "& <a>", '<Item name="DESCRIPTION" sample="4" role="description">&amp;amp; &amp;lt;a&amp;gt;</Item>'),
+        (
+            0,
+            "easy",
+            '<Item name="DESCRIPTION" sample="0" role="description">easy</Item>',
+        ),
+        (
+            1,
+            "<",
+            '<Item name="DESCRIPTION" sample="1" role="description">&amp;lt;</Item>',
+        ),
+        (
+            2,
+            ">",
+            '<Item name="DESCRIPTION" sample="2" role="description">&amp;gt;</Item>',
+        ),
+        (
+            3,
+            "&",
+            '<Item name="DESCRIPTION" sample="3" role="description">&amp;amp;</Item>',
+        ),
+        (
+            4,
+            "& <a>",
+            '<Item name="DESCRIPTION" sample="4" role="description">&amp;amp; &amp;lt;a&amp;gt;</Item>',
+        ),
     ],
 )
 def test_gdal_sample_description(sample: int, description: str, expected: str):
@@ -407,4 +427,9 @@ def test_cog_with_dask_smoke_test(gbox: GeoBox, tmp_path: Path, dtype):
     rr = fut.compute()
     assert str(rr) == fname
 
-
+    # Band names
+    img.attrs["long_name"] = ["red", "green", "blue"]
+    fname = str(tmp_path / "cog-bandnames.tif")
+    fut = save_cog_with_dask(img, fname, compression="deflate", level=2)
+    rr = fut.compute()
+    assert str(rr) == fname


### PR DESCRIPTION
The xarray and rioxarray packages use a dataset's `long_name` attribute to store band names.  This PR saves those band names in COGs written with `save_cog_with_dask`.  The names are written to be as compatible as possible with GDAL's band name writes.

This mechanism may also be used to write other GDAL metadata.

Resolves #138.