### PR TITLE
save_cog_with_dask: Handle single-band SYX

### DIFF
--- a/odc/geo/cog/_tifffile.py
+++ b/odc/geo/cog/_tifffile.py
@@ -155,7 +155,7 @@ def _make_empty_cog(
     ax, yaxis = yaxis_from_shape(shape, gbox)
     im_shape = shape_(shape[yaxis : yaxis + 2])
     photometric = PHOTOMETRIC.MINISBLACK
-    planarconfig = PLANARCONFIG.SEPARATE
+    planarconfig: Optional[PLANARCONFIG] = PLANARCONFIG.SEPARATE
     if ax == "YX":
         nsamples = 1
     elif ax == "YXS":

--- a/odc/geo/cog/_tifffile.py
+++ b/odc/geo/cog/_tifffile.py
@@ -165,6 +165,8 @@ def _make_empty_cog(
             photometric = PHOTOMETRIC.RGB
     else:
         nsamples = shape[0]
+        if nsamples == 1:
+            planarconfig = None
 
     buf = BytesIO()
 

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -432,7 +432,16 @@ def test_cog_with_dask_smoke_test(gbox: GeoBox, tmp_path: Path, dtype):
     rr = fut.compute()
     assert str(rr) == fname
 
-    # SYX
+    # SYX, one band
+    img = xr_zeros(gbox, dtype, chunks=(1, n, n), time=["2000"])
+    assert img.ndim == 3
+    assert img.odc.ydim == 1
+    fname = str(tmp_path / "cog-syx-one-band.tif")
+    fut = save_cog_with_dask(img, fname, compression="deflate", level=2)
+    rr = fut.compute()
+    assert str(rr) == fname
+
+    # SYX, multiple bands
     img = xr_zeros(gbox, dtype, chunks=(1, n, n), time=["2000", "2001"])
     assert img.ndim == 3
     assert img.odc.ydim == 1


### PR DESCRIPTION
Previously, `save_cog_with_dask` could not handle single-band SYX data.  The test added in this PR...

```python
    # SYX, one band
    img = xr_zeros(gbox, dtype, chunks=(1, n, n), time=["2000"])
    assert img.ndim == 3
    assert img.odc.ydim == 1
    fname = str(tmp_path / "cog-syx-one-band.tif")
    fut = save_cog_with_dask(img, fname, compression="deflate", level=2)
    rr = fut.compute()
    assert str(rr) == fname
```
...failed as follows:

```
tests/test_cog.py:440:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
odc/geo/cog/_tifffile.py:678: in save_cog_with_dask
    meta, hdr0 = _make_empty_cog(
odc/geo/cog/_tifffile.py:225: in _make_empty_cog
    tw.write(

...

E           ValueError: <PLANARCONFIG.SEPARATE: 2> does not match <StoredShape(frames=1, separate_samples=1, depth=1, length=1024, width=1024, contig_samples=1, extrasamples=0)>

/python/lib/python3.11/site-packages/tifffile/tifffile.py:2559: ValueError
```

This PR fixes the issue.  I loaded the TIFF file produced by the new test into QGIS and noted that it loaded correctly.