### PR TITLE
Tweak GeoBox extraction logic

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,7 @@ Interfacing with :py:class:`xarray.DataArray` and :py:class:`xarray.Dataset` cla
 
    ODCExtensionDa
    ODCExtensionDa.assign_crs
+   ODCExtensionDa.reload
    ODCExtensionDa.write_cog
    ODCExtensionDa.to_cog
    ODCExtensionDa.reproject
@@ -38,6 +39,7 @@ Interfacing with :py:class:`xarray.DataArray` and :py:class:`xarray.Dataset` cla
 
    ODCExtensionDs
    ODCExtensionDs.to_rgba
+   ODCExtensionDs.reload
 
    assign_crs
    rasterize

--- a/odc/geo/_version.py
+++ b/odc/geo/_version.py
@@ -1,3 +1,3 @@
 """version information only."""
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -904,6 +904,11 @@ class ODCExtensionDa(ODCExtension):
     def uncached(self) -> "ODCExtensionDa":
         return ODCExtensionDa(self._xx)
 
+    def reload(self) -> xarray.DataArray:
+        """Reload geospatial state info in-place."""
+        self._state = _locate_geo_info(self._xx)
+        return self._xx
+
     @property
     def ydim(self) -> int:
         """Index of the Y dimension."""
@@ -953,6 +958,11 @@ class ODCExtensionDs(ODCExtension):
     def __init__(self, ds: xarray.Dataset):
         ODCExtension.__init__(self, _locate_geo_info(ds))
         self._xx = ds
+
+    def reload(self) -> xarray.Dataset:
+        """Reload geospatial state info in-place."""
+        self._state = _locate_geo_info(self._xx)
+        return self._xx
 
     @property
     def uncached(self) -> "ODCExtensionDs":

--- a/odc/geo/testutils.py
+++ b/odc/geo/testutils.py
@@ -11,7 +11,7 @@ from affine import Affine
 from . import CRS
 from .geobox import GeoBox
 from .gridspec import GridSpec
-from .math import apply_affine, maybe_int
+from .math import apply_affine, approx_equal_affine
 
 # pylint: disable=invalid-name,
 
@@ -227,11 +227,6 @@ def daskify(xx, **kw):
         coords=xx.coords,
         attrs=xx.attrs,
     )
-
-
-def approx_equal_affine(a: Affine, b: Affine, tol: float = 1e-6) -> bool:
-    sx, z1, tx, z2, sy, ty = map(lambda v: maybe_int(v, tol), (~a * b)[:6])
-    return (sx, z1, tx, z2, sy, ty) == (1, 0, 0, 0, 1, 0)
 
 
 def approx_equal_geobox(a: GeoBox, b: GeoBox, tol: float = 1e-6) -> bool:

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -507,6 +507,25 @@ def test_extract_transform(geobox, bad_geo_transform: str):
 
 
 @pytest.mark.parametrize("geobox", TEST_GEOBOXES_SMALL_AXIS_ALIGNED)
+def test_reload(geobox):
+    xx = xr_zeros(geobox, dtype="int16")
+    assert xx.odc.geobox == geobox
+    assert xx.odc.reload() is xx
+    assert xx.odc.geobox == geobox
+
+    ds = xx.to_dataset(name="test")
+    assert ds.odc.geobox == geobox
+    assert ds.odc.reload() is ds
+    assert ds.odc.geobox == geobox
+
+    # change coords in-place
+    coord = xx[list(xx.coords)[0]]
+    coord.data[:] += 0.337
+    assert xx.odc.reload() is xx
+    assert xx.odc.geobox != geobox
+
+
+@pytest.mark.parametrize("geobox", TEST_GEOBOXES_SMALL_AXIS_ALIGNED)
 @pytest.mark.parametrize(
     "roi",
     [


### PR DESCRIPTION
- Bump precision of `GeoTransform` attribute
- Use data from `GeoTransform` when it's valid
- Use more precise approach for computing scale/translation values from coordinates
- Add `.odc.reload()` method to reload geo state (useful when coordinates are tweaked in place)
   - #127
   - #135 
- Bump version to `0.4.4`
