### PR TITLE
Fixes for rotated GeoBox representation on xarray

### DIFF
--- a/odc/geo/_version.py
+++ b/odc/geo/_version.py
@@ -1,3 +1,3 @@
 """version information only."""
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -336,11 +336,21 @@ def crop(
 
     .. seealso:: :py:meth:`odc.geo.xr.mask`
     """
+    meta: ODCExtension = xx.odc
+    sdims = meta.spatial_dims
+    gbox = meta.geobox
+
+    if sdims is None or gbox is None:
+        raise ValueError("Can't locate spatial dimensions")
+
+    if not isinstance(gbox, GeoBox):
+        raise ValueError("Can't crop GCPGeoBox")
+
     # Create new geobox with pixel grid of `xx` but enclosing `poly`.
-    poly_geobox = xx.odc.geobox.enclosing(poly)
+    poly_geobox = gbox.enclosing(poly)
 
     # Calculate ROI slices into `xx` for intersection between both geoboxes.
-    roi = xx.odc.geobox.overlap_roi(poly_geobox)
+    roi = gbox.overlap_roi(poly_geobox)
 
     # Verify that `poly` overlaps with `xx` by checking if the returned
     # ROI is empty
@@ -350,9 +360,6 @@ def crop(
         )
 
     # Crop spatial dims of `xx` using ROI
-    sdims = spatial_dims(xx)
-    if sdims is None:
-        raise ValueError("Can't locate spatial dimensions")
     xx_cropped = xx.isel({sdims[0]: roi[0], sdims[1]: roi[1]})
 
     # Optionally mask data outside rasterized `poly`

--- a/odc/geo/testutils.py
+++ b/odc/geo/testutils.py
@@ -201,7 +201,6 @@ def purge_crs_info(xx: xr.DataArray) -> xr.DataArray:
         for attr in attributes_to_clear:
             _x.attrs.pop(attr, None)
         _x.encoding.pop("grid_mapping", None)
-        _x.encoding.pop("_transform", None)
         return _x
 
     # remove non-dimensional coordinate, which is CRS in our case

--- a/tests/test_mpu_fs.py
+++ b/tests/test_mpu_fs.py
@@ -6,6 +6,8 @@ from uuid import uuid4
 
 import pytest
 
+_ = pytest.importorskip("odc.geo.cog")
+
 from odc.geo.cog._mpu_fs import MPUFileSink
 
 # pylint: disable=protected-access
@@ -16,7 +18,7 @@ def slurp(path: Path) -> bytes:
         return f.read()
 
 
-@pytest.mark.parametrize("parts_base", [f"parts-{uuid4().hex[:8]}", None])
+@pytest.mark.parametrize("parts_base", [f"parts-3782781", None])
 @pytest.mark.parametrize("num_parts", [1, 2, 3, 10])
 def test_filesink(tmp_path: Path, parts_base: str | None, num_parts: int):
     dst = Path(tmp_path / f"{uuid4().hex}.bin")

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -87,8 +87,7 @@ def test_geobox_xr_coords():
     assert cc["spatial_ref"].attrs["spatial_ref"] == gbox.crs.wkt
     assert isinstance(cc["spatial_ref"].attrs["grid_mapping_name"], str)
     assert isinstance(cc["spatial_ref"].attrs["GeoTransform"], str)
-    assert cc["x"].encoding["_transform"] == _gbox.affine[:6]
-    assert cc["y"].encoding["_transform"] == _gbox.affine[:6]
+    assert xr_zeros(_gbox, dtype="uint16").odc.geobox == _gbox
 
     # geographic CRS
     A = mkA(0, scale=(0.1, -0.1), translation=(10, 30))


### PR DESCRIPTION
- Rotated GeoBox didn't survive serialization to disk, and now does
   - Don't rely on custom `encoding["_transform"]` instead use attribute
- Improved detection of spatial dimensions with non-standard names
   - This change allows packing data arrays with different geo-registration into one `xarray.Dataset`
   - Bands with different native resolutions without upsampling is a good example of such use-case 
- Allow arbitrary names for dimensions in `xr_zeros|wrap_xr` (i.e. `dims=("T", "Y", "X", "B")`)
- Make it easy to force `y,x` names for spatial dimensions even when geobox is in 4326, `always_yx=True`
- Allow arbitrary number of non-spatial dimensions in any position relative to spatial dimensions
- Removed "LayerControl present" detection code in `.odc.explore` as it relies on internal details of `folium.Map`
   - ping: @robbibt, the idea is that if user is supplying existing map to `.explore()` then we won't try adding `LayerControl` or change map view, and just add ImageOverlay to the existing map
   - I had some issues with adding multiple images to the same map, looks like it's due to `LayerControl` and some problem/unexpected behaviour in `folium` that I have not fully debugged
- Mapping functions now expose optional `index=` parameter, used for layer ordering in folium/ipyleaflet