### PR TITLE
Fixes and additions for `.odc.reproject(..)`

### DIFF
--- a/odc/geo/_dask.py
+++ b/odc/geo/_dask.py
@@ -70,7 +70,7 @@ def _do_chunked_reproject(
     return dst
 
 
-def _dask_rio_reproject(
+def dask_rio_reproject(
     src: da.Array,
     s_gbox: Union[GeoBox, GCPGeoBox],
     d_gbox: GeoBox,
@@ -94,7 +94,6 @@ def _dask_rio_reproject(
 
     name: str = kwargs.pop("name", "reproject")
 
-    assert isinstance(s_gbox, GeoBox)
     gbt_src = GeoboxTiles(s_gbox, src.chunks[ydim : ydim + 2])
     gbt_dst = GeoboxTiles(d_gbox, chunks)
     d2s_idx = gbt_dst.grid_intersect(gbt_src)

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -821,9 +821,9 @@ def _xr_reproject_da(
         dst_nodata = src_nodata
 
     if is_dask_collection(src):
-        from ._dask import _dask_rio_reproject
+        from ._dask import dask_rio_reproject
 
-        dst: Any = _dask_rio_reproject(
+        dst: Any = dask_rio_reproject(
             src.data,
             src_gbox,
             dst_geobox,

--- a/tests/test_xr_interop.py
+++ b/tests/test_xr_interop.py
@@ -425,6 +425,9 @@ def test_xr_reproject(xx_epsg4326: xr.DataArray):
     assert xx.odc.geobox == dst_gbox
     assert xx.encoding["grid_mapping"] == "spatial_ref"
     assert "crs" not in xx.attrs
+    assert xx.dtype == xx_epsg4326.dtype
+
+    assert xx_epsg4326.odc.reproject(3857, dtype="float32").dtype == "float32"
 
     yy = xr.Dataset({"a": xx0, "b": xx0 + 1, "c": xr.DataArray([2, 3, 4])})
     assert isinstance(yy.odc, ODCExtensionDs)


### PR DESCRIPTION
- Allow changing output pixel type directly in `.odc.reproject(..., dtype="float32")` 
- Remove incorrect assert in dask version of `reproject` that erroneously prevented reprojection when operating on GCP inputs