### PR TITLE
Some fixes and maintenance

### DIFF
--- a/odc/geo/_interop.py
+++ b/odc/geo/_interop.py
@@ -75,6 +75,10 @@ def __getattr__(name):
             return False
 
         return is_dask_collection
+    if name == "__path__":
+        loader = globals().get("__loader__")
+        if loader is not None:
+            return loader.path
 
     raise AttributeError(f"module {__name__} has no attribute {name}")
 

--- a/odc/geo/_version.py
+++ b/odc/geo/_version.py
@@ -1,3 +1,3 @@
 """version information only."""
 
-__version__ = "0.4.7rc1"
+__version__ = "0.4.7rc2"

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -8,6 +8,7 @@ Add ``.odc.`` extension to :py:class:`xarray.Dataset` and :class:`xarray.DataArr
 from __future__ import annotations
 
 import functools
+import math
 import warnings
 from dataclasses import dataclass
 from datetime import datetime
@@ -591,6 +592,9 @@ def _extract_transform(
             # adjust transform
             #  world <- pix' <- pix
             transform = original_transform * transform
+
+        if any(map(math.isnan, transform)):
+            transform = original_transform
 
         if approx_equal_affine(transform, original_transform):
             transform = original_transform

--- a/odc/geo/warp.py
+++ b/odc/geo/warp.py
@@ -23,6 +23,7 @@ __all__ = [
     "resolve_fill_value",
     "rio_warp_affine",
     "rio_reproject",
+    "warp_affine",
 ]
 
 
@@ -84,6 +85,10 @@ def rio_warp_affine(
     return _rio_reproject(
         src, dst, s_gbox, d_gbox, resampling, src_nodata, fill_value, **kwargs
     )
+
+
+# backward compatibility wrapper
+warp_affine = rio_warp_affine
 
 
 def rio_reproject(


### PR DESCRIPTION
- put back `warp_affine` alias
- use `spatial_ref.attrs['GeoTransform']` as true geobox when spatial coordinates contain `NaN`, needed for lazy open of remote zarrs without reading coords from slow/inaccessible sources.
