### PR TITLE
Fix docs

### DIFF
--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -19,5 +19,5 @@ sphinx
 sphinx_rtd_theme
 sphinx-autodoc-typehints
 jupyter_sphinx
-geopandas
+geopandas<1
 ipykernel

--- a/odc/geo/crs.py
+++ b/odc/geo/crs.py
@@ -26,8 +26,6 @@ from pyproj.transformer import Transformer
 
 from .types import XY, Unset
 
-SomeCRS = Union[str, int, "CRS", _CRS, Dict[str, Any]]
-MaybeCRS = Union[SomeCRS, Unset, None]
 EPSG_UNSET = 0
 
 
@@ -394,6 +392,9 @@ class CRSMismatchError(ValueError):
     coordinate references.
     """
 
+
+SomeCRS = Union[str, int, CRS, _CRS, Dict[str, Any]]
+MaybeCRS = Union[SomeCRS, Unset, None]
 
 # fmt: off
 @overload


### PR DESCRIPTION
- use `geopandas<1`, because of `country_geom` #165 
- move `SomeCRS` type alias to be after `class CRS` to avoid issues with type resolution in doc building when compound type is using forward references.