### PR TITLE
fix small typo in _extract_geo_transform()

### DIFF
--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -5,6 +5,7 @@
 """
 Add ``.odc.`` extension to :py:class:`xarray.Dataset` and :class:`xarray.DataArray`.
 """
+
 from __future__ import annotations
 
 import functools
@@ -538,11 +539,11 @@ def _extract_gcps(crs_coord: xarray.DataArray) -> Optional[GCPMapping]:
 
 
 def _extract_geo_transform(crs_coord: xarray.DataArray) -> Optional[Affine]:
-    geo_transfrom_parts = crs_coord.attrs.get("GeoTransform", "").split(" ")
-    if len(geo_transfrom_parts) != 6:
+    geo_transform_parts = crs_coord.attrs.get("GeoTransform", "").split(" ")
+    if len(geo_transform_parts) != 6:
         return None
     try:
-        c, a, b, f, d, e = map(float, geo_transfrom_parts)
+        c, a, b, f, d, e = map(float, geo_transform_parts)
     except ValueError:
         return None
 


### PR DESCRIPTION
- Fix a small typo in [_extract_geo_transform()](https://github.com/opendatacube/odc-geo/blob/94ad126571cdddcf4884b0f9ea4024dde15d0208/odc/geo/_xr_interop.py#L540). The variable should probably be named `geo_transform_parts` instead of `geo_transfrom_parts`. 