### PR TITLE
Round gridspec tilesize to fix floating point precision issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,8 @@ jobs:
         run: |
           conda info
           conda list
-          mamba -V
+          # New version of mamba doesn't support -V
+          # mamba -V
           conda config --show-sources
           conda config --show
           printenv | sort

--- a/odc/geo/_dask.py
+++ b/odc/geo/_dask.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 from uuid import uuid4
 
 import dask.array as da
@@ -15,7 +15,7 @@ from .warp import Resampling, _rio_reproject, resampling_s2rio
 
 
 def _do_chunked_reproject(
-    d2s: Dict[Tuple[int, int], Sequence[Tuple[int, int]]],
+    d2s: Dict[Tuple[int, int], list[Tuple[int, int]]],
     src_gbt: GeoboxTiles,
     dst_gbt: GeoboxTiles,
     dst_idx: Tuple[int, int],

--- a/odc/geo/gridspec.py
+++ b/odc/geo/gridspec.py
@@ -66,9 +66,12 @@ class GridSpec:
         self.crs = norm_crs_or_error(crs)
         self._shape = tile_shape
         self.resolution = resolution
+
+        # This is an arbitrary rounding of 12 decimal places
+        # I don't know how to make it more robust
         self.tile_size = xy_(
-            tile_shape.x * abs(resolution.x),
-            tile_shape.y * abs(resolution.y),
+            round(tile_shape.x * abs(resolution.x), 12),
+            round(tile_shape.y * abs(resolution.y), 12),
         )
         self.origin = origin
 

--- a/tests/test_gridspec.py
+++ b/tests/test_gridspec.py
@@ -9,13 +9,43 @@ import numpy
 import pytest
 from pytest import approx
 
-from odc.geo import CRS, res_, resyx_, xy_, yx_
+from odc.geo import CRS, res_, resyx_, xy_, yx_, XY
 from odc.geo.geom import polygon
 from odc.geo.gridspec import GridSpec
 from odc.geo.testutils import SAMPLE_WKT_WITHOUT_AUTHORITY
 
 # pylint: disable=protected-access,use-implicit-booleaness-not-comparison
 # pylint: disable=comparison-with-itself,unnecessary-comprehension
+
+
+def test_gridspec_small():
+    print("Starting test for GridSpec")
+    WGS84GRID30 = GridSpec(
+        "EPSG:4326", tile_shape=(5000, 5000), resolution=0.0003, origin=XY(-180, -90)
+    )
+
+    assert WGS84GRID30.tile_shape == (5000, 5000)
+    assert WGS84GRID30.tile_size == XY(1.5, 1.5)
+
+    # Tile is at (-180 + 50*1.5) and (-90 + 50*1.5)
+    tile = (50, 50)
+    geobox = WGS84GRID30.tile_geobox(tile)
+    affine = geobox.affine
+
+    # Affine should be like this: (0.0003, 0, -105.0, 0, -0.0003, -13.5)
+    assert affine.a == 0.0003
+    assert affine.c == -105.0  # -180 + 50 * 1.5 * 0.0003
+    assert affine.f == -13.50  # -90 + 50 * 1.5 * 0.0003
+
+    # Tile is at (-180 + 200*1.5) and (-90 + 75*1.5)
+    tile = (200, 75)
+    geobox = WGS84GRID30.tile_geobox(tile)
+    affine = geobox.affine
+
+    # Affine should be like this: (0.0003, 0, 120.0, 0, -0.0003, 24.0)
+    assert affine.a == 0.0003
+    assert affine.c == 120.0  # -180 + 200 * 1.5 * 0.0003
+    assert affine.f == 24.0  # -90 + 75 * 1.5 * 0.0003
 
 
 def test_gridspec():


### PR DESCRIPTION
Fixes an issue where small resolutions (i.e., `0.003`) would lead to crazy coordinates in geoboxes for a gridspec, due to floating point issues.

For example, if you create a gridspec like this, the transform has a rounding error with a very small number added at the end:

```python
from odc.geo.gridspec import GridSpec, XY

WGS84GRID30 = GridSpec("EPSG:4326", tile_shape=(5000, 5000), resolution=0.0003, origin=XY(-180, -90))

tile = (50, 50)
geobox = WGS84GRID30.tile_geobox(tile)

geobox.affine
```
> Affine(0.0003, 0.0, -105.00000000000001, 0.0, -0.0003, -13.500000000000014)

The issue is caused when calculating the tile size (the width and height of the tile, in units of the gridspec), which works like this:

```python
from odc.geo.types import shape_, res_

tile_shape = shape_((5000, 5000))
resolution = res_(0.0003)

tile_shape.x * abs(resolution.x)
```

> `1.4999999999999998`

The proposed fix is to round these numbers at `12` decimal places, which is enough to fix this problem and I hope doesn't cause issues in other areas. New test included an all other tests pass.