### PR TITLE
Fix `write_cog` for geoboxes with null crs

### DIFF
--- a/odc/geo/cog/_rio.py
+++ b/odc/geo/cog/_rio.py
@@ -182,7 +182,7 @@ def _write_cog(
         "height": h,
         "count": nbands,
         "dtype": pix.dtype.name,
-        "crs": str(geobox.crs),
+        "crs": str(geobox.crs) if geobox.crs is not None else None,
         "transform": geobox.transform,
         **_default_cog_opts(
             blocksize=blocksize, shape=wh_(w, h), is_float=pix.dtype.kind == "f"


### PR DESCRIPTION
If a geobox has a CRS value of `None`, it will break `write-cog` - the crs value in `rio_opts` will be set to `str(None)`, which causes `rio_copy` to error: `rasterio.errors.CRSError: The WKT could not be parsed. OGR Error code 5`