### PR TITLE
Ensure correct roi precision with numpy 2

### DIFF
--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -383,13 +383,13 @@ def roi_boundary(roi: NormalizedROI, pts_per_side: int = 2) -> np.ndarray:
     roi needs to be in the normalised form, i.e. no open-ended start/stop,
 
     :returns:
-      ``Nx2 <float32>`` array of ``X,Y`` points on the perimeter of the envelope defined by ``roi``
+      ``Nx2 <float64>`` array of ``X,Y`` points on the perimeter of the envelope defined by ``roi``
 
     .. seealso:: :py:func:`~odc.geo.roi.roi_normalise`
     """
     yy, xx = roi
-    xx = np.linspace(xx.start, xx.stop, pts_per_side, dtype="float32")
-    yy = np.linspace(yy.start, yy.stop, pts_per_side, dtype="float32")
+    xx = np.linspace(xx.start, xx.stop, pts_per_side, dtype="float64")
+    yy = np.linspace(yy.start, yy.stop, pts_per_side, dtype="float64")
 
     return polygon_path(xx, yy, closed=False).T
 


### PR DESCRIPTION
Numpy 2.0 introduces breaking changes around implicit dtype conversions, causing a loss of precision when computing the roi for  inputs with small resolution values.
See the [original issue](https://github.com/opendatacube/datacube-core/issues/1655) for further details and minimal reproducible example, which uses `datacube.utils.geometry` but produces the same results with the corresponding `odc-geo` methods.