### PR TITLE
Fix nodata retrieval logic to ensure compatibility with rioxarray

### DIFF
--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -1024,11 +1024,11 @@ class ODCExtensionDa(ODCExtension):
         encoding = self._xx.encoding
 
         for k in ["nodata", "_FillValue"]:
-            nodata = attrs.get(k, ())
-            if nodata == ():
-                nodata = encoding.get(k, ())
+            nodata = attrs.get(k, numpy._NoValue)
+            if nodata is numpy._NoValue:
+                nodata = encoding.get(k, numpy._NoValue)
 
-            if nodata == ():
+            if nodata is numpy._NoValue:
                 continue
 
             if nodata is None:

--- a/odc/geo/_xr_interop.py
+++ b/odc/geo/_xr_interop.py
@@ -50,7 +50,7 @@ from .math import (
 )
 from .overlap import compute_output_geobox
 from .roi import roi_is_empty
-from .types import Nodata, Resolution, SomeNodata, SomeResolution, SomeShape, xy_
+from .types import Nodata, Resolution, SomeNodata, SomeResolution, SomeShape, Unset, xy_
 
 # pylint: disable=import-outside-toplevel
 # pylint: disable=too-many-lines
@@ -79,6 +79,8 @@ STANDARD_SPATIAL_DIMS = [
     ("latitude", "longitude"),
     ("lat", "lon"),
 ]
+
+_NoValue = Unset()
 
 
 @dataclass
@@ -1024,11 +1026,11 @@ class ODCExtensionDa(ODCExtension):
         encoding = self._xx.encoding
 
         for k in ["nodata", "_FillValue"]:
-            nodata = attrs.get(k, numpy._NoValue)
-            if nodata is numpy._NoValue:
-                nodata = encoding.get(k, numpy._NoValue)
+            nodata = attrs.get(k, _NoValue)
+            if nodata is _NoValue:
+                nodata = encoding.get(k, _NoValue)
 
-            if nodata is numpy._NoValue:
+            if nodata is _NoValue:
                 continue
 
             if nodata is None:


### PR DESCRIPTION
Currently, if we set nodata using rioxarray, odc-geo fails to retrieve the nodata value.
This PR changes nodata retrieval logic to ensure compatibility with nodata values set using rioxarray.

Before the proposed changes, we have the problem shown in the screenshot below. After the proposed changes, no errors were observed.
**Before fix**
![Screenshot 2024-12-09 144556](https://github.com/user-attachments/assets/bb2534e3-424b-48fa-9969-eabad4d8459c)
**After fix**
![Screenshot 2024-12-09 144855](https://github.com/user-attachments/assets/7f538604-1854-4f5c-a994-efbaef17ae3f)
