### PR TITLE
feat: save COGs with dask to azure

### DIFF
--- a/odc/geo/_interop.py
+++ b/odc/geo/_interop.py
@@ -43,6 +43,14 @@ class _LibChecker:
     def tifffile(self) -> bool:
         return self._check("tifffile")
 
+    @property
+    def azure(self) -> bool:
+        return self._check("azure.storage.blob")
+
+    @property
+    def botocore(self) -> bool:
+        return self._check("botocore")
+
     @staticmethod
     def _check(lib_name: str) -> bool:
         return importlib.util.find_spec(lib_name) is not None

--- a/odc/geo/cog/_az.py
+++ b/odc/geo/cog/_az.py
@@ -1,0 +1,191 @@
+import base64
+from typing import Any, Union
+
+from azure.storage.blob import BlobBlock, BlobServiceClient
+from dask.delayed import Delayed
+
+from ._mpu import mpu_write
+from ._multipart import MultiPartUploadBase
+
+
+class AzureLimits:
+    """
+    Common Azure writer settings.
+    """
+
+    @property
+    def min_write_sz(self) -> int:
+        # Azure minimum write size for blocks (default is 4 MiB)
+        return 4 * (1 << 20)
+
+    @property
+    def max_write_sz(self) -> int:
+        # Azure maximum write size for blocks (default is 100 MiB)
+        return 100 * (1 << 20)
+
+    @property
+    def min_part(self) -> int:
+        return 1
+
+    @property
+    def max_part(self) -> int:
+        # Azure supports up to 50,000 blocks per blob
+        return 50_000
+
+
+class MultiPartUpload(AzureLimits, MultiPartUploadBase):
+    def __init__(
+        self, account_url: str, container: str, blob: str, credential: Any = None
+    ):
+        """
+        Initialise Azure multipart upload.
+
+        :param account_url: URL of the Azure storage account.
+        :param container: Name of the container.
+        :param blob: Name of the blob.
+        :param credential: Authentication credentials (e.g., SAS token or key).
+        """
+        self.account_url = account_url
+        self.container = container
+        self.blob = blob
+        self.credential = credential
+
+        # Initialise Azure Blob service client
+        self.blob_service_client = BlobServiceClient(
+            account_url=account_url, credential=credential
+        )
+        self.container_client = self.blob_service_client.get_container_client(container)
+        self.blob_client = self.container_client.get_blob_client(blob)
+
+        self.block_ids: list[str] = []
+
+    def initiate(self, **kwargs) -> str:
+        """
+        Initialise the upload. No-op for Azure.
+        """
+        return "azure-block-upload"
+
+    def write_part(self, part: int, data: bytes) -> dict[str, Any]:
+        """
+        Stage a block in Azure.
+
+        :param part: Part number (unique).
+        :param data: Data for this part.
+        :return: A dictionary containing part information.
+        """
+        block_id = base64.b64encode(f"block-{part}".encode()).decode()
+        self.blob_client.stage_block(block_id=block_id, data=data)
+        self.block_ids.append(block_id)
+        return {"PartNumber": part, "BlockId": block_id}
+
+    def finalise(self, parts: list[dict[str, Any]]) -> str:
+        """
+        Commit the block list to finalise the upload.
+
+        :param parts: List of uploaded parts metadata.
+        :return: The ETag of the finalised blob.
+        """
+        block_list = [BlobBlock(block_id=part["BlockId"]) for part in parts]
+        self.blob_client.commit_block_list(block_list)
+        return self.blob_client.get_blob_properties().etag
+
+    def cancel(self):
+        """
+        Cancel the upload by clearing the block list.
+        """
+        self.block_ids.clear()
+
+    @property
+    def url(self) -> str:
+        """
+        Get the Azure blob URL.
+
+        :return: The full URL of the blob.
+        """
+        return self.blob_client.url
+
+    @property
+    def started(self) -> bool:
+        """
+        Check if any blocks have been staged.
+
+        :return: True if blocks have been staged, False otherwise.
+        """
+        return bool(self.block_ids)
+
+    def writer(self, kw: dict[str, Any], client: Any = None):
+        """
+        Return a stateless writer compatible with Dask.
+        """
+        return DelayedAzureWriter(self, kw)
+
+    def upload(
+        self,
+        chunks: Union["dask.bag.Bag", list["dask.bag.Bag"]],
+        *,
+        mk_header: Any = None,
+        mk_footer: Any = None,
+        user_kw: dict[str, Any] = None,
+        writes_per_chunk: int = 1,
+        spill_sz: int = 20 * (1 << 20),
+        client: Any = None,
+        **kw,
+    ) -> "Delayed":
+        """
+        Upload chunks to Azure Blob Storage with multipart uploads.
+
+        :param chunks: Dask bag of chunks to upload.
+        :param mk_header: Function to create header data.
+        :param mk_footer: Function to create footer data.
+        :param user_kw: User-provided metadata for the upload.
+        :param writes_per_chunk: Number of writes per chunk.
+        :param spill_sz: Spill size for buffering data.
+        :param client: Dask client for distributed execution.
+        :return: A Dask delayed object representing the finalised upload.
+        """
+        write = self.writer(kw, client=client) if spill_sz else None
+        return mpu_write(
+            chunks,
+            write,
+            mk_header=mk_header,
+            mk_footer=mk_footer,
+            user_kw=user_kw,
+            writes_per_chunk=writes_per_chunk,
+            spill_sz=spill_sz,
+            dask_name_prefix="azure-finalise",
+        )
+
+
+class DelayedAzureWriter(AzureLimits):
+    """
+    Dask-compatible writer for Azure Blob Storage multipart uploads.
+    """
+
+    def __init__(self, mpu: MultiPartUpload, kw: dict[str, Any]):
+        """
+        Initialise the Azure writer.
+
+        :param mpu: MultiPartUpload instance.
+        :param kw: Additional parameters for the writer.
+        """
+        self.mpu = mpu
+        self.kw = kw  # Additional metadata like ContentType
+
+    def __call__(self, part: int, data: bytes) -> dict[str, Any]:
+        """
+        Write a single part to Azure Blob Storage.
+
+        :param part: Part number.
+        :param data: Chunk data.
+        :return: Metadata for the written part.
+        """
+        return self.mpu.write_part(part, data)
+
+    def finalise(self, parts: list[dict[str, Any]]) -> str:
+        """
+        Finalise the upload by committing the block list.
+
+        :param parts: List of uploaded parts metadata.
+        :return: ETag of the finalised blob.
+        """
+        return self.mpu.finalise(parts)

--- a/odc/geo/cog/_az.py
+++ b/odc/geo/cog/_az.py
@@ -1,8 +1,7 @@
 import base64
 from typing import Any, Union
 
-from azure.storage.blob import BlobBlock, BlobServiceClient
-from dask.delayed import Delayed
+import dask
 
 from ._mpu import mpu_write
 from ._multipart import MultiPartUploadBase
@@ -51,6 +50,9 @@ class AzMultiPartUpload(AzureLimits, MultiPartUploadBase):
         self.credential = credential
 
         # Initialise Azure Blob service client
+        # pylint: disable=import-outside-toplevel,import-error
+        from azure.storage.blob import BlobServiceClient
+
         self.blob_service_client = BlobServiceClient(
             account_url=account_url, credential=credential
         )
@@ -85,6 +87,9 @@ class AzMultiPartUpload(AzureLimits, MultiPartUploadBase):
         :param parts: List of uploaded parts metadata.
         :return: The ETag of the finalised blob.
         """
+        # pylint: disable=import-outside-toplevel,import-error
+        from azure.storage.blob import BlobBlock
+
         block_list = [BlobBlock(block_id=part["BlockId"]) for part in parts]
         self.blob_client.commit_block_list(block_list)
         return self.blob_client.get_blob_properties().etag
@@ -121,7 +126,7 @@ class AzMultiPartUpload(AzureLimits, MultiPartUploadBase):
 
     def upload(
         self,
-        chunks: Union["dask.bag.Bag", list["dask.bag.Bag"]],
+        chunks: Union[dask.bag.Bag, list[dask.bag.Bag]],
         *,
         mk_header: Any = None,
         mk_footer: Any = None,
@@ -130,7 +135,7 @@ class AzMultiPartUpload(AzureLimits, MultiPartUploadBase):
         spill_sz: int = 20 * (1 << 20),
         client: Any = None,
         **kw,
-    ) -> "Delayed":
+    ) -> dask.delayed.Delayed:
         """
         Upload chunks to Azure Blob Storage with multipart uploads.
 

--- a/odc/geo/cog/_az.py
+++ b/odc/geo/cog/_az.py
@@ -33,7 +33,7 @@ class AzureLimits:
         return 50_000
 
 
-class MultiPartUpload(AzureLimits, MultiPartUploadBase):
+class AzMultiPartUpload(AzureLimits, MultiPartUploadBase):
     def __init__(
         self, account_url: str, container: str, blob: str, credential: Any = None
     ):
@@ -161,11 +161,11 @@ class DelayedAzureWriter(AzureLimits):
     Dask-compatible writer for Azure Blob Storage multipart uploads.
     """
 
-    def __init__(self, mpu: MultiPartUpload, kw: dict[str, Any]):
+    def __init__(self, mpu: AzMultiPartUpload, kw: dict[str, Any]):
         """
         Initialise the Azure writer.
 
-        :param mpu: MultiPartUpload instance.
+        :param mpu: AzMultiPartUpload instance.
         :param kw: Additional parameters for the writer.
         """
         self.mpu = mpu

--- a/odc/geo/cog/_multipart.py
+++ b/odc/geo/cog/_multipart.py
@@ -7,9 +7,11 @@ multipart uploads across storage backends.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Union
+from typing import Any, Union, TYPE_CHECKING
 
-import dask.bag
+if TYPE_CHECKING:
+    # pylint: disable=import-outside-toplevel,import-error
+    import dask.bag
 
 
 class MultiPartUploadBase(ABC):
@@ -18,34 +20,28 @@ class MultiPartUploadBase(ABC):
     @abstractmethod
     def initiate(self, **kwargs) -> str:
         """Initiate a multipart upload and return an identifier."""
-        pass
 
     @abstractmethod
     def write_part(self, part: int, data: bytes) -> dict[str, Any]:
         """Upload a single part."""
-        pass
 
     @abstractmethod
     def finalise(self, parts: list[dict[str, Any]]) -> str:
         """Finalise the upload with a list of parts."""
-        pass
 
     @abstractmethod
     def cancel(self, other: str = ""):
         """Cancel the multipart upload."""
-        pass
 
     @property
     @abstractmethod
     def url(self) -> str:
         """Return the URL of the upload target."""
-        pass
 
     @property
     @abstractmethod
     def started(self) -> bool:
         """Check if the multipart upload has been initiated."""
-        pass
 
     @abstractmethod
     def writer(self, kw: dict[str, Any], *, client: Any = None) -> Any:
@@ -55,7 +51,6 @@ class MultiPartUploadBase(ABC):
         :param kw: Additional parameters for the writer.
         :param client: Dask client for distributed execution.
         """
-        pass
 
     @abstractmethod
     def upload(
@@ -64,7 +59,7 @@ class MultiPartUploadBase(ABC):
         *,
         mk_header: Any = None,
         mk_footer: Any = None,
-        user_kw: dict[str, Any] = None,
+        user_kw: dict[str, Any] | None = None,
         writes_per_chunk: int = 1,
         spill_sz: int = 20 * (1 << 20),
         client: Any = None,
@@ -82,4 +77,3 @@ class MultiPartUploadBase(ABC):
         :param client: Dask client for distributed execution.
         :return: A Dask delayed object representing the finalised upload.
         """
-        pass

--- a/odc/geo/cog/_multipart.py
+++ b/odc/geo/cog/_multipart.py
@@ -1,0 +1,81 @@
+"""
+Multipart upload interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Union
+
+import dask.bag
+
+
+class MultiPartUploadBase(ABC):
+    """Abstract base class for multipart upload."""
+
+    @abstractmethod
+    def initiate(self, **kwargs) -> str:
+        """Initiate a multipart upload and return an identifier."""
+        pass
+
+    @abstractmethod
+    def write_part(self, part: int, data: bytes) -> dict[str, Any]:
+        """Upload a single part."""
+        pass
+
+    @abstractmethod
+    def finalise(self, parts: list[dict[str, Any]]) -> str:
+        """Finalise the upload with a list of parts."""
+        pass
+
+    @abstractmethod
+    def cancel(self, other: str = ""):
+        """Cancel the multipart upload."""
+        pass
+
+    @property
+    @abstractmethod
+    def url(self) -> str:
+        """Return the URL of the upload target."""
+        pass
+
+    @property
+    @abstractmethod
+    def started(self) -> bool:
+        """Check if the multipart upload has been initiated."""
+        pass
+
+    @abstractmethod
+    def writer(self, kw: dict[str, Any], *, client: Any = None) -> Any:
+        """
+        Return a Dask-compatible writer for multipart uploads.
+
+        :param kw: Additional parameters for the writer.
+        :param client: Dask client for distributed execution.
+        """
+        pass
+
+    @abstractmethod
+    def upload(
+        self,
+        chunks: Union["dask.bag.Bag", list["dask.bag.Bag"]],
+        *,
+        mk_header: Any = None,
+        mk_footer: Any = None,
+        user_kw: dict[str, Any] = None,
+        writes_per_chunk: int = 1,
+        spill_sz: int = 20 * (1 << 20),
+        client: Any = None,
+        **kw,
+    ) -> Any:
+        """
+        Orchestrate the upload process with multipart uploads.
+
+        :param chunks: Dask bag of chunks to upload.
+        :param mk_header: Function to create header data.
+        :param mk_footer: Function to create footer data.
+        :param user_kw: User-provided metadata for the upload.
+        :param writes_per_chunk: Number of writes per chunk.
+        :param spill_sz: Spill size for buffering data.
+        :param client: Dask client for distributed execution.
+        :return: A Dask delayed object representing the finalised upload.
+        """
+        pass

--- a/odc/geo/cog/_multipart.py
+++ b/odc/geo/cog/_multipart.py
@@ -1,5 +1,9 @@
 """
 Multipart upload interface.
+
+Defines the `MultiPartUploadBase` class for implementing multipart upload functionality.
+This interface standardises methods for initiating, uploading, and finalising
+multipart uploads across storage backends.
 """
 
 from abc import ABC, abstractmethod

--- a/odc/geo/cog/_s3.py
+++ b/odc/geo/cog/_s3.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from cachetools import cached
 
-from ._mpu import PartsWriter, SomeData, mpu_write
+from ._mpu import PartsWriter, SomeData
 from ._multipart import MultiPartUploadBase
 
 if TYPE_CHECKING:
@@ -197,30 +197,9 @@ class S3MultiPartUpload(S3Limits, MultiPartUploadBase):
             writer.prep_client(client)
         return writer
 
-    def upload(
-        self,
-        chunks: "dask.bag.Bag" | list["dask.bag.Bag"],
-        *,
-        mk_header: Any = None,
-        mk_footer: Any = None,
-        user_kw: dict[str, Any] | None = None,
-        writes_per_chunk: int = 1,
-        spill_sz: int = 20 * (1 << 20),
-        client: Any = None,
-        **kw,
-    ) -> "Delayed":
-        """Upload chunks to S3 with multipart uploads."""
-        write = self.writer(kw, client=client) if spill_sz else None
-        return mpu_write(
-            chunks,
-            write,
-            mk_header=mk_header,
-            mk_footer=mk_footer,
-            user_kw=user_kw,
-            writes_per_chunk=writes_per_chunk,
-            spill_sz=spill_sz,
-            dask_name_prefix="s3finalise",
-        )
+    def dask_name_prefix(self) -> str:
+        """Return the Dask name prefix for S3."""
+        return "s3finalise"
 
 
 def _safe_get(v, timeout=0.1):

--- a/odc/geo/cog/_s3.py
+++ b/odc/geo/cog/_s3.py
@@ -10,12 +10,14 @@ from typing import TYPE_CHECKING, Any, Optional
 from cachetools import cached
 
 from ._mpu import PartsWriter, SomeData, mpu_write
+from ._multipart import MultiPartUploadBase
 
 if TYPE_CHECKING:
     import dask.bag
-    import distributed
     from botocore.credentials import ReadOnlyCredentials
     from dask.delayed import Delayed
+
+    import distributed
 
 _state: dict[str, Any] = {}
 
@@ -68,7 +70,7 @@ class S3Limits:
         return 10_000
 
 
-class MultiPartUpload(S3Limits):
+class MultiPartUpload(S3Limits, MultiPartUploadBase):
     """
     Dask to S3 dumper.
     """
@@ -195,7 +197,6 @@ class MultiPartUpload(S3Limits):
             writer.prep_client(client)
         return writer
 
-    # pylint: disable=too-many-arguments
     def upload(
         self,
         chunks: "dask.bag.Bag" | list["dask.bag.Bag"],

--- a/odc/geo/cog/_s3.py
+++ b/odc/geo/cog/_s3.py
@@ -70,7 +70,7 @@ class S3Limits:
         return 10_000
 
 
-class MultiPartUpload(S3Limits, MultiPartUploadBase):
+class S3MultiPartUpload(S3Limits, MultiPartUploadBase):
     """
     Dask to S3 dumper.
     """
@@ -237,7 +237,7 @@ class DelayedS3Writer(S3Limits):
 
     # pylint: disable=import-outside-toplevel,import-error
 
-    def __init__(self, mpu: MultiPartUpload, kw: dict[str, Any]):
+    def __init__(self, mpu: S3MultiPartUpload, kw: dict[str, Any]):
         self.mpu = mpu
         self.kw = kw  # mostly ContentType= kinda thing
         self._shared_var: Optional["distributed.Variable"] = None
@@ -263,7 +263,7 @@ class DelayedS3Writer(S3Limits):
             self._shared_var = Variable(self._build_name("MPUpload"), client)
         return self._shared_var
 
-    def _ensure_init(self, final_write: bool = False) -> MultiPartUpload:
+    def _ensure_init(self, final_write: bool = False) -> S3MultiPartUpload:
         # pylint: disable=too-many-return-statements
         mpu = self.mpu
         if mpu.started:

--- a/odc/geo/gcp.py
+++ b/odc/geo/gcp.py
@@ -102,9 +102,16 @@ class GCPMapping:
 
     def points(self) -> Tuple[Geometry, Geometry]:
         """Return multipoint geometries for (Pixel, World)."""
+        pix_points: list[tuple[float, float]] = [
+            (float(p[0]), float(p[1])) for p in self._pix.tolist()
+        ]
+        wld_points: list[tuple[float, float]] = [
+            (float(p[0]), float(p[1])) for p in self._wld.tolist()
+        ]
+
         return (
-            multipoint(self._pix.tolist(), None),
-            multipoint(self._wld.tolist(), self.crs),
+            multipoint(pix_points, None),
+            multipoint(wld_points, self.crs),
         )
 
     def __dask_tokenize__(self):

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -320,7 +320,6 @@ class BoundingBox(Sequence[float]):
             self.crs,
         )
 
-
     def qr2sample(
         self,
         n: int,
@@ -358,7 +357,8 @@ class BoundingBox(Sequence[float]):
             n_side = int(numpy.round(sample_density * min(nx, ny))) + 1
             n_side = max(2, n_side)
             edge_pts = [
-                (float(ep[0]), float(ep[1])) for ep in list(self.boundary(n_side).coords[:-1])
+                (float(ep[0]), float(ep[1]))
+                for ep in list(self.boundary(n_side).coords[:-1])
             ]
             if padding is None:
                 padding = 0.3 * min(nx, ny) / (n_side - 1)
@@ -376,6 +376,7 @@ class BoundingBox(Sequence[float]):
         ] + edge_pts
 
         return multipoint(coords, self.crs)
+
 
 def wrap_shapely(method):
     """

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -320,6 +320,7 @@ class BoundingBox(Sequence[float]):
             self.crs,
         )
 
+
     def qr2sample(
         self,
         n: int,
@@ -350,13 +351,15 @@ class BoundingBox(Sequence[float]):
         ny = y1 - y0
         pts = quasi_random_r2(n, offset=offset)
         s = numpy.asarray([nx, ny], dtype="float32")
-        edge_pts = []
+        edge_pts: list[tuple[float, float]] = []
 
         if with_edges:
             sample_density = numpy.sqrt(n / (nx * ny))
             n_side = int(numpy.round(sample_density * min(nx, ny))) + 1
             n_side = max(2, n_side)
-            edge_pts = self.boundary(n_side).coords[:-1]
+            edge_pts = [
+                (float(ep[0]), float(ep[1])) for ep in list(self.boundary(n_side).coords[:-1])
+            ]
             if padding is None:
                 padding = 0.3 * min(nx, ny) / (n_side - 1)
 
@@ -368,8 +371,11 @@ class BoundingBox(Sequence[float]):
         pts[:, 0] += x0
         pts[:, 1] += y0
 
-        return multipoint(pts.tolist() + edge_pts, self.crs)
+        coords: list[tuple[float, float]] = [
+            (float(p[0]), float(p[1])) for p in pts.tolist()
+        ] + edge_pts
 
+        return multipoint(coords, self.crs)
 
 def wrap_shapely(method):
     """

--- a/odc/geo/roi.py
+++ b/odc/geo/roi.py
@@ -284,7 +284,7 @@ class VariableSizedTiles:
     @property
     def chunks(self) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
         """Dask compatible chunk rerpesentation."""
-        y, x = (tuple(np.diff(idx).tolist()) for idx in self._offsets)
+        y, x = (tuple(map(int, np.diff(idx))) for idx in self._offsets)
         return (y, x)
 
     def locate(self, pix: SomeIndex2d) -> Tuple[int, int]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,10 +54,14 @@ tiff =
 s3 =
     boto3
 
+az =
+    azure-storage-blob
+
 all =
     %(warp)s
     %(tiff)s
     %(s3)s
+    %(az)s
 
 test =
     pytest

--- a/tests/test_az.py
+++ b/tests/test_az.py
@@ -1,37 +1,50 @@
-"""Tests for the Azure MultiPartUpload class."""
+"""Tests for the Azure AzMultiPartUpload class."""
 
+import base64
 import unittest
 from unittest.mock import MagicMock, patch
 
-from odc.geo.cog._az import MultiPartUpload
+# Conditional import for Azure support
+try:
+    from odc.geo.cog._az import AzMultiPartUpload
+
+    HAVE_AZURE = True
+except ImportError:
+    AzMultiPartUpload = None
+    HAVE_AZURE = False
 
 
-def test_mpu_init():
-    """Basic test for the MultiPartUpload class."""
-    account_url = "https://account_name.blob.core.windows.net"
-    mpu = MultiPartUpload(account_url, "container", "some.blob", None)
-    if mpu.account_url != account_url:
-        raise AssertionError(f"mpu.account_url should be '{account_url}'.")
-    if mpu.container != "container":
-        raise AssertionError("mpu.container should be 'container'.")
-    if mpu.blob != "some.blob":
-        raise AssertionError("mpu.blob should be 'some.blob'.")
-    if mpu.credential is not None:
-        raise AssertionError("mpu.credential should be 'None'.")
+def require_azure(test_func):
+    """Decorator to skip tests if Azure dependencies are not installed."""
+    return unittest.skipUnless(HAVE_AZURE, "Azure dependencies are not installed")(
+        test_func
+    )
 
 
-class TestMultiPartUpload(unittest.TestCase):
-    """Test the MultiPartUpload class."""
+class TestAzMultiPartUpload(unittest.TestCase):
+    """Test the AzMultiPartUpload class."""
 
+    @require_azure
+    def test_mpu_init(self):
+        """Basic test for AzMultiPartUpload initialization."""
+        account_url = "https://account_name.blob.core.windows.net"
+        mpu = AzMultiPartUpload(account_url, "container", "some.blob", None)
+
+        self.assertEqual(mpu.account_url, account_url)
+        self.assertEqual(mpu.container, "container")
+        self.assertEqual(mpu.blob, "some.blob")
+        self.assertIsNone(mpu.credential)
+
+    @require_azure
     @patch("odc.geo.cog._az.BlobServiceClient")
     def test_azure_multipart_upload(self, mock_blob_service_client):
-        """Test the MultiPartUpload class."""
-        # Arrange - mock the Azure Blob SDK
-        # Mock the blob client and its methods
+        """Test the full Azure AzMultiPartUpload functionality."""
+        # Arrange - Mock Azure Blob SDK client structure
         mock_blob_client = MagicMock()
         mock_container_client = MagicMock()
-        mcc = mock_container_client
-        mock_blob_service_client.return_value.get_container_client.return_value = mcc
+        mock_blob_service_client.return_value.get_container_client.return_value = (
+            mock_container_client
+        )
         mock_container_client.get_blob_client.return_value = mock_blob_client
 
         # Simulate return values for Azure Blob SDK methods
@@ -43,32 +56,41 @@ class TestMultiPartUpload(unittest.TestCase):
         blob = "mock-blob"
         credential = "mock-sas-token"
 
-        # Act - create an instance of MultiPartUpload and call its methods
-        azure_upload = MultiPartUpload(account_url, container, blob, credential)
+        # Act
+        azure_upload = AzMultiPartUpload(account_url, container, blob, credential)
         upload_id = azure_upload.initiate()
         part1 = azure_upload.write_part(1, b"first chunk of data")
         part2 = azure_upload.write_part(2, b"second chunk of data")
         etag = azure_upload.finalise([part1, part2])
 
-        # Assert - check the results
-        # Check that the initiate method behaves as expected
-        self.assertEqual(upload_id, "azure-block-upload")
+        # Correctly calculate block IDs
+        block_id1 = base64.b64encode(b"block-1").decode("utf-8")
+        block_id2 = base64.b64encode(b"block-2").decode("utf-8")
 
-        # Verify the calls to Azure Blob SDK methods
+        # Assert
+        self.assertEqual(upload_id, "azure-block-upload")
+        self.assertEqual(etag, "mock-etag")
+
+        # Verify BlobServiceClient instantiation
         mock_blob_service_client.assert_called_once_with(
             account_url=account_url, credential=credential
         )
-        mock_blob_client.stage_block.assert_any_call(
-            part1["BlockId"], b"first chunk of data"
-        )
-        mock_blob_client.stage_block.assert_any_call(
-            part2["BlockId"], b"second chunk of data"
-        )
-        mock_blob_client.commit_block_list.assert_called_once()
-        self.assertEqual(etag, "mock-etag")
 
-        # Verify block list passed during finalise
+        # Verify stage_block calls
+        mock_blob_client.stage_block.assert_any_call(
+            block_id=block_id1, data=b"first chunk of data"
+        )
+        mock_blob_client.stage_block.assert_any_call(
+            block_id=block_id2, data=b"second chunk of data"
+        )
+
+        # Verify commit_block_list was called correctly
         block_list = mock_blob_client.commit_block_list.call_args[0][0]
         self.assertEqual(len(block_list), 2)
-        self.assertEqual(block_list[0].id, part1["BlockId"])
-        self.assertEqual(block_list[1].id, part2["BlockId"])
+        self.assertEqual(block_list[0].id, block_id1)
+        self.assertEqual(block_list[1].id, block_id2)
+        mock_blob_client.commit_block_list.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_az.py
+++ b/tests/test_az.py
@@ -1,96 +1,80 @@
 """Tests for the Azure AzMultiPartUpload class."""
 
 import base64
-import unittest
 from unittest.mock import MagicMock, patch
 
-# Conditional import for Azure support
-try:
-    from odc.geo.cog._az import AzMultiPartUpload
+import pytest
 
-    HAVE_AZURE = True
-except ImportError:
-    AzMultiPartUpload = None
-    HAVE_AZURE = False
+pytest.importorskip("azure.storage.blob")
+from odc.geo.cog._az import AzMultiPartUpload  # noqa: E402
 
 
-def require_azure(test_func):
-    """Decorator to skip tests if Azure dependencies are not installed."""
-    return unittest.skipUnless(HAVE_AZURE, "Azure dependencies are not installed")(
-        test_func
+@pytest.fixture
+def azure_mpu():
+    """Fixture for initializing AzMultiPartUpload."""
+    account_url = "https://account_name.blob.core.windows.net"
+    return AzMultiPartUpload(account_url, "container", "some.blob", None)
+
+
+def test_mpu_init(azure_mpu):
+    """Basic test for AzMultiPartUpload initialization."""
+    assert azure_mpu.account_url == "https://account_name.blob.core.windows.net"
+    assert azure_mpu.container == "container"
+    assert azure_mpu.blob == "some.blob"
+    assert azure_mpu.credential is None
+
+
+@patch("odc.geo.cog._az.BlobServiceClient")
+def test_azure_multipart_upload(mock_blob_service_client):
+    """Test the full Azure AzMultiPartUpload functionality."""
+    # Mock Azure Blob SDK client structure
+    mock_blob_client = MagicMock()
+    mock_container_client = MagicMock()
+    mock_blob_service_client.return_value.get_container_client.return_value = (
+        mock_container_client
+    )
+    mock_container_client.get_blob_client.return_value = mock_blob_client
+
+    # Simulate return values for Azure Blob SDK methods
+    mock_blob_client.get_blob_properties.return_value.etag = "mock-etag"
+
+    # Test parameters
+    account_url = "https://mockaccount.blob.core.windows.net"
+    container = "mock-container"
+    blob = "mock-blob"
+    credential = "mock-sas-token"
+
+    # Create an instance of AzMultiPartUpload and call its methods
+    azure_upload = AzMultiPartUpload(account_url, container, blob, credential)
+    upload_id = azure_upload.initiate()
+    part1 = azure_upload.write_part(1, b"first chunk of data")
+    part2 = azure_upload.write_part(2, b"second chunk of data")
+    etag = azure_upload.finalise([part1, part2])
+
+    # Define block IDs
+    block_id1 = base64.b64encode(b"block-1").decode("utf-8")
+    block_id2 = base64.b64encode(b"block-2").decode("utf-8")
+
+    # Verify the results
+    assert upload_id == "azure-block-upload"
+    assert etag == "mock-etag"
+
+    # Verify BlobServiceClient instantiation
+    mock_blob_service_client.assert_called_once_with(
+        account_url=account_url, credential=credential
     )
 
+    # Verify stage_block calls
+    mock_blob_client.stage_block.assert_any_call(
+        block_id=block_id1, data=b"first chunk of data"
+    )
+    mock_blob_client.stage_block.assert_any_call(
+        block_id=block_id2, data=b"second chunk of data"
+    )
 
-class TestAzMultiPartUpload(unittest.TestCase):
-    """Test the AzMultiPartUpload class."""
-
-    @require_azure
-    def test_mpu_init(self):
-        """Basic test for AzMultiPartUpload initialization."""
-        account_url = "https://account_name.blob.core.windows.net"
-        mpu = AzMultiPartUpload(account_url, "container", "some.blob", None)
-
-        self.assertEqual(mpu.account_url, account_url)
-        self.assertEqual(mpu.container, "container")
-        self.assertEqual(mpu.blob, "some.blob")
-        self.assertIsNone(mpu.credential)
-
-    @require_azure
-    @patch("odc.geo.cog._az.BlobServiceClient")
-    def test_azure_multipart_upload(self, mock_blob_service_client):
-        """Test the full Azure AzMultiPartUpload functionality."""
-        # Arrange - Mock Azure Blob SDK client structure
-        mock_blob_client = MagicMock()
-        mock_container_client = MagicMock()
-        mock_blob_service_client.return_value.get_container_client.return_value = (
-            mock_container_client
-        )
-        mock_container_client.get_blob_client.return_value = mock_blob_client
-
-        # Simulate return values for Azure Blob SDK methods
-        mock_blob_client.get_blob_properties.return_value.etag = "mock-etag"
-
-        # Test parameters
-        account_url = "https://mockaccount.blob.core.windows.net"
-        container = "mock-container"
-        blob = "mock-blob"
-        credential = "mock-sas-token"
-
-        # Act
-        azure_upload = AzMultiPartUpload(account_url, container, blob, credential)
-        upload_id = azure_upload.initiate()
-        part1 = azure_upload.write_part(1, b"first chunk of data")
-        part2 = azure_upload.write_part(2, b"second chunk of data")
-        etag = azure_upload.finalise([part1, part2])
-
-        # Correctly calculate block IDs
-        block_id1 = base64.b64encode(b"block-1").decode("utf-8")
-        block_id2 = base64.b64encode(b"block-2").decode("utf-8")
-
-        # Assert
-        self.assertEqual(upload_id, "azure-block-upload")
-        self.assertEqual(etag, "mock-etag")
-
-        # Verify BlobServiceClient instantiation
-        mock_blob_service_client.assert_called_once_with(
-            account_url=account_url, credential=credential
-        )
-
-        # Verify stage_block calls
-        mock_blob_client.stage_block.assert_any_call(
-            block_id=block_id1, data=b"first chunk of data"
-        )
-        mock_blob_client.stage_block.assert_any_call(
-            block_id=block_id2, data=b"second chunk of data"
-        )
-
-        # Verify commit_block_list was called correctly
-        block_list = mock_blob_client.commit_block_list.call_args[0][0]
-        self.assertEqual(len(block_list), 2)
-        self.assertEqual(block_list[0].id, block_id1)
-        self.assertEqual(block_list[1].id, block_id2)
-        mock_blob_client.commit_block_list.assert_called_once()
-
-
-if __name__ == "__main__":
-    unittest.main()
+    # Verify commit_block_list was called correctly
+    block_list = mock_blob_client.commit_block_list.call_args[0][0]
+    assert len(block_list) == 2
+    assert block_list[0].id == block_id1
+    assert block_list[1].id == block_id2
+    mock_blob_client.commit_block_list.assert_called_once()

--- a/tests/test_az.py
+++ b/tests/test_az.py
@@ -1,0 +1,74 @@
+"""Tests for the Azure MultiPartUpload class."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from odc.geo.cog._az import MultiPartUpload
+
+
+def test_mpu_init():
+    """Basic test for the MultiPartUpload class."""
+    account_url = "https://account_name.blob.core.windows.net"
+    mpu = MultiPartUpload(account_url, "container", "some.blob", None)
+    if mpu.account_url != account_url:
+        raise AssertionError(f"mpu.account_url should be '{account_url}'.")
+    if mpu.container != "container":
+        raise AssertionError("mpu.container should be 'container'.")
+    if mpu.blob != "some.blob":
+        raise AssertionError("mpu.blob should be 'some.blob'.")
+    if mpu.credential is not None:
+        raise AssertionError("mpu.credential should be 'None'.")
+
+
+class TestMultiPartUpload(unittest.TestCase):
+    """Test the MultiPartUpload class."""
+
+    @patch("odc.geo.cog._az.BlobServiceClient")
+    def test_azure_multipart_upload(self, mock_blob_service_client):
+        """Test the MultiPartUpload class."""
+        # Arrange - mock the Azure Blob SDK
+        # Mock the blob client and its methods
+        mock_blob_client = MagicMock()
+        mock_container_client = MagicMock()
+        mcc = mock_container_client
+        mock_blob_service_client.return_value.get_container_client.return_value = mcc
+        mock_container_client.get_blob_client.return_value = mock_blob_client
+
+        # Simulate return values for Azure Blob SDK methods
+        mock_blob_client.get_blob_properties.return_value.etag = "mock-etag"
+
+        # Test parameters
+        account_url = "https://mockaccount.blob.core.windows.net"
+        container = "mock-container"
+        blob = "mock-blob"
+        credential = "mock-sas-token"
+
+        # Act - create an instance of MultiPartUpload and call its methods
+        azure_upload = MultiPartUpload(account_url, container, blob, credential)
+        upload_id = azure_upload.initiate()
+        part1 = azure_upload.write_part(1, b"first chunk of data")
+        part2 = azure_upload.write_part(2, b"second chunk of data")
+        etag = azure_upload.finalise([part1, part2])
+
+        # Assert - check the results
+        # Check that the initiate method behaves as expected
+        self.assertEqual(upload_id, "azure-block-upload")
+
+        # Verify the calls to Azure Blob SDK methods
+        mock_blob_service_client.assert_called_once_with(
+            account_url=account_url, credential=credential
+        )
+        mock_blob_client.stage_block.assert_any_call(
+            part1["BlockId"], b"first chunk of data"
+        )
+        mock_blob_client.stage_block.assert_any_call(
+            part2["BlockId"], b"second chunk of data"
+        )
+        mock_blob_client.commit_block_list.assert_called_once()
+        self.assertEqual(etag, "mock-etag")
+
+        # Verify block list passed during finalise
+        block_list = mock_blob_client.commit_block_list.call_args[0][0]
+        self.assertEqual(len(block_list), 2)
+        self.assertEqual(block_list[0].id, part1["BlockId"])
+        self.assertEqual(block_list[1].id, part2["BlockId"])

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,9 +1,29 @@
-from odc.geo.cog._s3 import MultiPartUpload
+"""Tests for odc.geo.cog._s3."""
 
-# TODO: moto
+import unittest
+
+from odc.geo.cog._s3 import S3MultiPartUpload
+
+# Conditional import for S3 support
+try:
+    from odc.geo.cog._s3 import S3MultiPartUpload
+
+    HAVE_S3 = True
+except ImportError:
+    S3MultiPartUpload = None
+    HAVE_S3 = False
 
 
+def require_s3(test_func):
+    """Decorator to skip tests if s3 dependencies are not installed."""
+    return unittest.skipUnless(HAVE_S3, "s3 dependencies are not installed")(test_func)
+
+
+@require_s3
 def test_s3_mpu():
-    mpu = MultiPartUpload("bucket", "file.dat")
-    assert mpu.bucket == "bucket"
-    assert mpu.key == "file.dat"
+    """Test S3MultiPartUpload class initialization."""
+    mpu = S3MultiPartUpload("bucket", "file.dat")
+    if mpu.bucket != "bucket":
+        raise ValueError("Invalid bucket")
+    if mpu.key != "file.dat":
+        raise ValueError("Invalid key")


### PR DESCRIPTION
This PR introduces Azure Blob Storage support for saving COGs with Dask, complementing the existing AWS S3 support.

- Implements a MultiPartUpload class in _az.py to handle Azure-specific multipart upload operations, including block staging, finalization, and cancellation.
- Adds MultiPartUploadBase in _multipart.py to provide a shared interface for multipart uploads, applicable to both Azure and S3 implementations.
- Updates save_cog_with_dask to recognize Azure URLs and integrate the Azure multipart upload workflow.
- Adds unit tests in tests/test_az.py using mocked Azure SDK to verify functionality specific to Azure Blob Storage.

Here’s a simple test I ran to verify the Azure implementation:

```python
import dask.distributed
import planetary_computer as pc
from odc.geo.cog._tifffile import save_cog_with_dask
from odc.stac import configure_rio, stac_load
from pystac_client import Client

# Setup Dask client for efficient processing
client = dask.distributed.Client()
configure_rio(cloud_defaults=True, client=client)

# Query STAC API for Sentinel-2 data
catalog = Client.open("https://planetarycomputer.microsoft.com/api/stac/v1")
query = catalog.search(
    collections=["sentinel-2-l2a"],
    datetime="2019-06",
    query={"s2:mgrs_tile": dict(eq="06VVN")},
)
items = list(query.items())
print(f"Found {len(items)} datasets")

# Load Sentinel-2 data with specific bands
resolution = 40 
xx = stac_load(
    items,
    bands=["SCL"],
    resolution=resolution,
    chunks={"x": 2048, "y": 2048},
    patch_url=pc.sign,
    dtype="uint16",
    nodata=0,
)

# Select a single time slice for saving
to_save = xx.SCL.isel(time=3)

# Azure Blob Storage details
blob_name = f"SCL-{to_save.time.dt.strftime('%Y%m%d').item()}.tif"
azure_url = f"az://{container}/{blob_name}"


result = save_cog_with_dask(
    to_save,
    dst=f"az://{container}/{blob_name}",
    compression="DEFLATE",
    predictor=2,
    overview_resampling="nearest",
    azure={
        "account_url": f"https://{storage_account}.blob.core.windows.net",
        "credential": sas_token,  # can be blob specific or container wide
    },
    blocksize=[512, 512],
)

# Compute the result to trigger the actual upload
result.compute()
print(f"COG successfully uploaded to: {azure_url}")
```

While implementing this, I noticed a couple of quirks in the original code:

- Spelling Inconsistencies: Words like finalise vs. finalize were used. I  used **`ise`** rather than `ize`.
- Typing Updates: The code inconsistently uses Dict/List from typing vs. built-ins (dict/list). I've changed it to Dict and List since the dev-env.yml specifies python=3.8 (but I hadn't used python 3.8 in ages).

As this is my first PR here, I look forward to feedback and suggestions for improvement!