### PR TITLE
Chore/cleanup

### DIFF
--- a/dev-env.yml
+++ b/dev-env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python =3.8
+  - python =3.10
 
   # odc-geo dependencies
   - pyproj

--- a/odc/geo/cog/_mpu.py
+++ b/odc/geo/cog/_mpu.py
@@ -8,13 +8,10 @@ from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Iterable,
     Iterator,
-    List,
     Optional,
     Protocol,
-    Tuple,
     Union,
 )
 
@@ -35,9 +32,9 @@ SomeData = Union[bytes, bytearray]
 class PartsWriter(Protocol):
     """Protocol for labeled parts data writer."""
 
-    def __call__(self, part: int, data: SomeData) -> Dict[str, Any]: ...
+    def __call__(self, part: int, data: SomeData) -> dict[str, Any]: ...
 
-    def finalise(self, parts: List[Dict[str, Any]]) -> Any: ...
+    def finalise(self, parts: list[dict[str, Any]]) -> Any: ...
 
     @property
     def min_write_sz(self) -> int: ...
@@ -76,8 +73,8 @@ class MPUChunk:
         write_credits: int,
         data: Optional[bytearray] = None,
         left_data: Optional[bytearray] = None,
-        parts: Optional[List[Dict[str, Any]]] = None,
-        observed: Optional[List[Tuple[int, Any]]] = None,
+        parts: Optional[list[dict[str, Any]]] = None,
+        observed: Optional[list[tuple[int, Any]]] = None,
         is_final: bool = False,
         lhs_keep: int = 0,
     ) -> None:
@@ -85,8 +82,8 @@ class MPUChunk:
         self.write_credits = write_credits
         self.data = bytearray() if data is None else data
         self.left_data = bytearray() if left_data is None else left_data
-        self.parts: List[Dict[str, Any]] = [] if parts is None else parts
-        self.observed: List[Tuple[int, Any]] = [] if observed is None else observed
+        self.parts: list[dict[str, Any]] = [] if parts is None else parts
+        self.observed: list[tuple[int, Any]] = [] if observed is None else observed
         self.is_final = is_final
         self.lhs_keep = lhs_keep
         # if supplying data must also supply observed
@@ -221,7 +218,7 @@ class MPUChunk:
         write: PartsWriter,
         leftPartId: Optional[int] = None,
         finalise: bool = True,
-    ) -> Tuple[int, Any]:
+    ) -> tuple[int, Any]:
         rr = None
         if not self.started_write:
             assert not self.left_data
@@ -343,7 +340,7 @@ class MPUChunk:
 
     @staticmethod
     def collate_substreams(
-        substreams: List["dask.bag.Item"],
+        substreams: list["dask.bag.Item"],
         *,
         write: Optional[PartsWriter] = None,
         spill_sz: int = 0,
@@ -423,7 +420,7 @@ def mpu_write(
 
 
 def _mpu_collate_op(
-    substreams: List[MPUChunk],
+    substreams: list[MPUChunk],
     *,
     write: Optional[PartsWriter] = None,
     spill_sz: int = 0,
@@ -439,7 +436,7 @@ def _mpu_collate_op(
 
 def _mpu_append_chunks_op(
     mpus: Iterable[MPUChunk],
-    chunks: Iterable[Tuple[bytes, Any]],
+    chunks: Iterable[tuple[bytes, Any]],
     write: Optional[PartsWriter] = None,
     spill_sz: int = 0,
 ):

--- a/odc/geo/cog/_s3.py
+++ b/odc/geo/cog/_s3.py
@@ -282,7 +282,7 @@ class DelayedS3Writer(S3Limits):
         uploadId = _safe_get(shared_state, 0.1)
 
         if uploadId is not None:
-            # someone else initialized it
+            # someone else initialised it
             mpu.uploadId = uploadId
             return mpu
 
@@ -290,7 +290,7 @@ class DelayedS3Writer(S3Limits):
         with lock:
             uploadId = _safe_get(shared_state, 0.1)
             if uploadId is not None:
-                # someone else initialized it while we were getting a lock
+                # someone else initialised it while we were getting a lock
                 mpu.uploadId = uploadId
                 return mpu
 

--- a/odc/geo/cog/_tifffile.py
+++ b/odc/geo/cog/_tifffile.py
@@ -21,10 +21,9 @@ from .._interop import have
 from ..geobox import GeoBox
 from ..math import resolve_nodata
 from ..types import Shape2d, SomeNodata, Unset, shape_
-from ._az import MultiPartUpload as AzMultiPartUpload
 from ._mpu import mpu_write
 from ._mpu_fs import MPUFileSink
-from ._s3 import MultiPartUpload as S3MultiPartUpload, s3_parse_url
+from ._s3 import MultiPartUpload, s3_parse_url
 from ._shared import (
     GDAL_COMP,
     GEOTIFF_TAGS,


### PR DESCRIPTION
Cleanup changes split from [another PR](https://github.com/opendatacube/odc-geo/pull/195):
- This changes the default from python 3.8 to python 3.10 for the dev env (following what is used in the .github/workflows).
- Changes spelling defaults from words like `finalize` to `finalise` (sorry for the UK push, happy to go the other way, just want consistency)
- add some docstrings to functions
- use built in types for dict, list and tuple rather than from typing import Dict, List, Tuple. This is not implemented library-wide here, as I was only touching some files for the other PR. Arguably using `Optional` can also be dropped, as `var[list[str]] = None` is valid python.