### PR TITLE
Fix excessive warnings when writing COGs

### DIFF
--- a/odc/geo/cog/_rio.py
+++ b/odc/geo/cog/_rio.py
@@ -268,10 +268,10 @@ def _write_cog(
                         return bytes(mem2.getbuffer())
 
                 rio_copy(
-                    tmp, 
-                    path, 
-                    driver="GTiff", 
-                    copy_src_overviews=True, 
+                    tmp,
+                    path,
+                    driver="GTiff",
+                    copy_src_overviews=True,
                     **_without(
                         rio_opts,
                         "width",

--- a/odc/geo/cog/_rio.py
+++ b/odc/geo/cog/_rio.py
@@ -267,7 +267,22 @@ def _write_cog(
                         )
                         return bytes(mem2.getbuffer())
 
-                rio_copy(tmp, path, driver="GTiff", copy_src_overviews=True, **rio_opts)
+                rio_copy(
+                    tmp, 
+                    path, 
+                    driver="GTiff", 
+                    copy_src_overviews=True, 
+                    **_without(
+                        rio_opts,
+                        "width",
+                        "height",
+                        "count",
+                        "dtype",
+                        "crs",
+                        "transform",
+                        "nodata",
+                    ),
+                )
 
     return path
 

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -58,6 +58,11 @@ def test_write_cog(gbox: GeoBox):
     )
     assert len(img_bytes) == len(img_bytes2)
 
+    # Verify COG can be written to file and read back
+    img.odc.write_cog("output_cog.tif")
+    with rio_open("output_cog.tif") as ds:
+        assert ds.read(1) is not None
+
 
 @pytest.mark.parametrize(
     ["scales", "offsets", "units"],


### PR DESCRIPTION
Based in discussion in #203, this implements a fix to exclude "width", "height", "count", "dtype", "crs", "transform", "nodata" kwargs from `rio_opts`, matching the approach taken for in-memory COGs.