### PR TITLE
fix: Allow final flush despite insufficient write credits in MPUChunk

### DIFF
--- a/odc/geo/cog/_mpu.py
+++ b/odc/geo/cog/_mpu.py
@@ -185,7 +185,7 @@ class MPUChunk:
             return len(_data)
 
         def can_flush(pw: PartsWriter):
-            if self.write_credits < 1:
+            if self.write_credits < 1 and not self.is_final:
                 return False
             if self.started_write:
                 return self.is_final or len(data) >= pw.min_write_sz
@@ -201,7 +201,8 @@ class MPUChunk:
             if write is None:
                 raise RuntimeError("Flush required but no writer provided")
 
-            assert can_flush(write)
+            if not self.is_final:
+                assert can_flush(write)
             return _flush_data(write)
 
         # Haven't started writing yet


### PR DESCRIPTION
closes https://github.com/opendatacube/odc-geo/issues/185

- Relax the flush logic in MPUChunk.flush_rhs() so that the final flush is allowed even when write_credits < 1.
- Modify the can_flush function to bypass the write credit check if self.is_final is True.
- This change prevents assertion failures during the final flush when exporting large COGs with many overview layers on Azure.
- Ensures that remaining data is properly flushed without needing extra write credits, while keeping non-final flush behavior unchanged.

Aims to address this AssertionError when writing a large COG with `odc.geo.cog.save_cog_with_dask`.
```
  File "dask/utils.py", line 77, in apply
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "odc/geo/cog/_mpu.py", line 496, in _finalizer_dask_op
    _, rr = _root.flush(write, leftPartId=1, finalise=True)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "odc/geo/cog/_mpu.py", line 239, in flush
    bytes_written = self.flush_rhs(write)
                    ^^^^^^^^^^^^^^^^^^^^^
  File "odc/geo/cog/_mpu.py", line 204, in flush_rhs
    assert can_flush(write)
           ^^^^^^^^^^^^^^^^
```