### PR TITLE
Stop the parameters with `None` from sending to gdal

### DIFF
--- a/odc/geo/warp.py
+++ b/odc/geo/warp.py
@@ -184,6 +184,8 @@ def _rio_reproject(
         #    https://github.com/opendatacube/datacube-core/issues/1448
         kwargs.update(XSCALE=1, YSCALE=1)
 
+    kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
     dtype_remap = {"int8": "int16", "bool": "uint8"}
 
     def _alias_or_convert(arr: np.ndarray) -> Tuple[np.ndarray, bool]:


### PR DESCRIPTION
As the title, to close issue #224, and re-enable the option of using the default computation in `gdal`. It doesn't affect the behaviour expected by others using this function.