### PR TITLE
Fix GEOSException when reprojecting antimeridian-spanning geometries

### DIFF
--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -253,7 +253,11 @@ class GeoBoxBase:
         return span / npoints
 
     def footprint(
-        self, crs: SomeCRS, buffer: float = 0, npoints: int = 100, wrapdateline: bool = False
+        self,
+        crs: SomeCRS,
+        buffer: float = 0,
+        npoints: int = 100,
+        wrapdateline: bool = False,
     ) -> Geometry:
         """
         Compute footprint in foreign CRS.
@@ -270,7 +274,11 @@ class GeoBoxBase:
             buffer = buffer * max(*self.resolution.xy)
             ext = ext.buffer(buffer)
 
-        return ext.to_crs(crs, resolution=self._reproject_resolution(npoints), wrapdateline=wrapdateline).dropna()
+        return ext.to_crs(
+            crs,
+            resolution=self._reproject_resolution(npoints),
+            wrapdateline=wrapdateline,
+        ).dropna()
 
     @property
     def geographic_extent(self) -> Geometry:
@@ -1519,6 +1527,7 @@ class GeoboxTiles:
         For every tile in this :py:class:`GeoboxTiles` find every tile in ``other`` that
         intersects with this ``tile``.
         """
+        # pylint: disable=too-many-branches
         A = self._check_linear(src)
         if A is not None:
             return self._grid_intersect_linear(src, A)
@@ -1531,7 +1540,7 @@ class GeoboxTiles:
                 src_footprint = (
                     src.base.footprint(4326, 2) & self.base.footprint(4326, 2)
                 ).to_crs(self.base.crs)
-            except Exception as e:
+            except Exception:  # pylint: disable=broad-exception-caught
                 # Handle antimeridian-spanning geometries that cause GEOSException
                 # or other projection issues
                 try:
@@ -1542,12 +1551,19 @@ class GeoboxTiles:
                     # Compute intersection in 4326 with antimeridian-aware geometries
                     intersection_4326 = src_fp_4326 & self_fp_4326
                     src_footprint = intersection_4326.to_crs(self.base.crs)
-                except Exception:
+                except Exception:  # pylint: disable=broad-exception-caught
                     # Final fallback: use source footprint directly without intersection
                     # This is less efficient but avoids complete failure
                     try:
-                        src_footprint = src.base.footprint(self.base.crs, 2, wrapdateline=True)
-                    except Exception:
+                        # Ensure we have a valid CRS before calling footprint
+                        if self.base.crs is not None:
+                            src_footprint = src.base.footprint(
+                                self.base.crs, 2, wrapdateline=True
+                            )
+                        else:
+                            # Fallback to using source extent if target CRS is None
+                            src_footprint = src.base.extent
+                    except Exception:  # pylint: disable=broad-exception-caught
                         # Last resort: use extent directly if available
                         if src.base.crs == self.base.crs:
                             src_footprint = src.base.extent
@@ -1555,7 +1571,12 @@ class GeoboxTiles:
                             # Use a very conservative approach: full world bounds
                             # This will be inefficient but won't crash
                             world_bounds = geom.box(-180, -90, 180, 90, "EPSG:4326")
-                            src_footprint = world_bounds.to_crs(self.base.crs)
+                            if self.base.crs is not None:
+                                src_footprint = world_bounds.to_crs(self.base.crs)
+                            else:
+                                # If target CRS is None, use world bounds in
+                                # WGS84
+                                src_footprint = world_bounds
 
         xy_chunks_with_data = list(self.tiles(src_footprint))
         deps: Dict[Tuple[int, int], List[Tuple[int, int]]] = {}

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -269,7 +269,7 @@ class GeoBoxBase:
         if buffer != 0:
             buffer = buffer * max(*self.resolution.xy)
             ext = ext.buffer(buffer)
-        
+
         return ext.to_crs(crs, resolution=self._reproject_resolution(npoints), wrapdateline=wrapdateline).dropna()
 
     @property
@@ -1538,7 +1538,7 @@ class GeoboxTiles:
                     # Try using wrapdateline=True for more robust antimeridian handling
                     src_fp_4326 = src.base.footprint(4326, 2, wrapdateline=True)
                     self_fp_4326 = self.base.footprint(4326, 2, wrapdateline=True)
-                    
+
                     # Compute intersection in 4326 with antimeridian-aware geometries
                     intersection_4326 = src_fp_4326 & self_fp_4326
                     src_footprint = intersection_4326.to_crs(self.base.crs)

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -253,7 +253,7 @@ class GeoBoxBase:
         return span / npoints
 
     def footprint(
-        self, crs: SomeCRS, buffer: float = 0, npoints: int = 100
+        self, crs: SomeCRS, buffer: float = 0, npoints: int = 100, wrapdateline: bool = False
     ) -> Geometry:
         """
         Compute footprint in foreign CRS.
@@ -262,14 +262,15 @@ class GeoBoxBase:
         :param buffer: amount to buffer in source pixels before transforming
         :param npoints: number of points per-side to use, higher number
                         is slower but more accurate
+        :param wrapdateline: Handle geometries that cross the antimeridian
         """
         assert self.crs is not None
         ext = self.extent
         if buffer != 0:
             buffer = buffer * max(*self.resolution.xy)
             ext = ext.buffer(buffer)
-
-        return ext.to_crs(crs, resolution=self._reproject_resolution(npoints)).dropna()
+        
+        return ext.to_crs(crs, resolution=self._reproject_resolution(npoints), wrapdateline=wrapdateline).dropna()
 
     @property
     def geographic_extent(self) -> Geometry:
@@ -1526,9 +1527,35 @@ class GeoboxTiles:
             src_footprint = src.base.extent
         else:
             # compute "robust" source footprint in CRS of self via espg:4326
-            src_footprint = (
-                src.base.footprint(4326, 2) & self.base.footprint(4326, 2)
-            ).to_crs(self.base.crs)
+            try:
+                src_footprint = (
+                    src.base.footprint(4326, 2) & self.base.footprint(4326, 2)
+                ).to_crs(self.base.crs)
+            except Exception as e:
+                # Handle antimeridian-spanning geometries that cause GEOSException
+                # or other projection issues
+                try:
+                    # Try using wrapdateline=True for more robust antimeridian handling
+                    src_fp_4326 = src.base.footprint(4326, 2, wrapdateline=True)
+                    self_fp_4326 = self.base.footprint(4326, 2, wrapdateline=True)
+                    
+                    # Compute intersection in 4326 with antimeridian-aware geometries
+                    intersection_4326 = src_fp_4326 & self_fp_4326
+                    src_footprint = intersection_4326.to_crs(self.base.crs)
+                except Exception:
+                    # Final fallback: use source footprint directly without intersection
+                    # This is less efficient but avoids complete failure
+                    try:
+                        src_footprint = src.base.footprint(self.base.crs, 2, wrapdateline=True)
+                    except Exception:
+                        # Last resort: use extent directly if available
+                        if src.base.crs == self.base.crs:
+                            src_footprint = src.base.extent
+                        else:
+                            # Use a very conservative approach: full world bounds
+                            # This will be inefficient but won't crash
+                            world_bounds = geom.box(-180, -90, 180, 90, "EPSG:4326")
+                            src_footprint = world_bounds.to_crs(self.base.crs)
 
         xy_chunks_with_data = list(self.tiles(src_footprint))
         deps: Dict[Tuple[int, int], List[Tuple[int, int]]] = {}

--- a/tests/test_antimeridian.py
+++ b/tests/test_antimeridian.py
@@ -54,7 +54,9 @@ def test_pacific_antimeridian_scenario() -> None:
     tiles = GeoboxTiles(pacific_geobox, tile_shape=(50, 50))
 
     # Target in Web Mercator
-    mercator_transform = Affine.translation(18000000, 1000000) * Affine.scale(10000, -10000)
+    mercator_transform = Affine.translation(18000000, 1000000) * Affine.scale(
+        10000, -10000
+    )
     mercator_geobox = GeoBox((100, 200), mercator_transform, epsg3857)
     mercator_tiles = GeoboxTiles(mercator_geobox, tile_shape=(25, 25))
 

--- a/tests/test_antimeridian.py
+++ b/tests/test_antimeridian.py
@@ -12,18 +12,18 @@ def test_antimeridian_sinusoidal_grid_intersect() -> None:
     sin_crs = CRS("+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs")
     transform = Affine.translation(-20037508, 5000000) * Affine.scale(10000, -10000)
     large_geobox = GeoBox((1000, 500), transform, sin_crs)
-    
+
     # Create tiles
     tiles = GeoboxTiles(large_geobox, tile_shape=(256, 256))
-    
+
     # Create target geobox in WGS84
     target_transform = Affine.translation(170, 10) * Affine.scale(0.1, -0.1)
     target_geobox = GeoBox((100, 100), target_transform, epsg4326)
     target_tiles = GeoboxTiles(target_geobox, tile_shape=(50, 50))
-    
+
     # This should not raise GEOSException
     intersections = tiles.grid_intersect(target_tiles)
-    
+
     # Should find some intersections
     assert isinstance(intersections, dict)
     # The exact number depends on the overlap, but it should work without crashing
@@ -34,11 +34,11 @@ def test_footprint_with_wrapdateline() -> None:
     # Create a simple geobox
     transform = Affine.translation(170, 10) * Affine.scale(0.1, -0.1)
     geobox = GeoBox((100, 100), transform, epsg4326)
-    
+
     # Test footprint with wrapdateline=True (should not raise)
     footprint = geobox.footprint(3857, wrapdateline=True)
     assert footprint is not None
-    
+
     # Test footprint with wrapdateline=False (default behavior)
     footprint_default = geobox.footprint(3857, wrapdateline=False)
     assert footprint_default is not None
@@ -49,17 +49,15 @@ def test_pacific_antimeridian_scenario() -> None:
     # Create a geobox spanning from 170°E to -170°W (crosses antimeridian)
     transform = Affine.translation(170, 10) * Affine.scale(0.1, -0.1)
     pacific_geobox = GeoBox((200, 400), transform, epsg4326)  # 20° x 40°
-    
+
     # Create tiles
     tiles = GeoboxTiles(pacific_geobox, tile_shape=(50, 50))
-    
+
     # Target in Web Mercator
     mercator_transform = Affine.translation(18000000, 1000000) * Affine.scale(10000, -10000)
     mercator_geobox = GeoBox((100, 200), mercator_transform, epsg3857)
     mercator_tiles = GeoboxTiles(mercator_geobox, tile_shape=(25, 25))
-    
+
     # This should work without GEOSException
     intersections = tiles.grid_intersect(mercator_tiles)
     assert isinstance(intersections, dict)
-
-

--- a/tests/test_antimeridian.py
+++ b/tests/test_antimeridian.py
@@ -1,0 +1,65 @@
+import pytest
+from affine import Affine
+
+from odc.geo import CRS
+from odc.geo.geobox import GeoBox, GeoboxTiles
+from odc.geo.testutils import epsg3857, epsg4326
+
+
+def test_antimeridian_sinusoidal_grid_intersect() -> None:
+    """Test that grid_intersect works with antimeridian-spanning sinusoidal data."""
+    # Create a sinusoidal projection GeoBox that spans the antimeridian
+    sin_crs = CRS("+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs")
+    transform = Affine.translation(-20037508, 5000000) * Affine.scale(10000, -10000)
+    large_geobox = GeoBox((1000, 500), transform, sin_crs)
+    
+    # Create tiles
+    tiles = GeoboxTiles(large_geobox, tile_shape=(256, 256))
+    
+    # Create target geobox in WGS84
+    target_transform = Affine.translation(170, 10) * Affine.scale(0.1, -0.1)
+    target_geobox = GeoBox((100, 100), target_transform, epsg4326)
+    target_tiles = GeoboxTiles(target_geobox, tile_shape=(50, 50))
+    
+    # This should not raise GEOSException
+    intersections = tiles.grid_intersect(target_tiles)
+    
+    # Should find some intersections
+    assert isinstance(intersections, dict)
+    # The exact number depends on the overlap, but it should work without crashing
+
+
+def test_footprint_with_wrapdateline() -> None:
+    """Test that footprint method accepts wrapdateline parameter."""
+    # Create a simple geobox
+    transform = Affine.translation(170, 10) * Affine.scale(0.1, -0.1)
+    geobox = GeoBox((100, 100), transform, epsg4326)
+    
+    # Test footprint with wrapdateline=True (should not raise)
+    footprint = geobox.footprint(3857, wrapdateline=True)
+    assert footprint is not None
+    
+    # Test footprint with wrapdateline=False (default behavior)
+    footprint_default = geobox.footprint(3857, wrapdateline=False)
+    assert footprint_default is not None
+
+
+def test_pacific_antimeridian_scenario() -> None:
+    """Test a realistic Pacific Ocean antimeridian scenario."""
+    # Create a geobox spanning from 170°E to -170°W (crosses antimeridian)
+    transform = Affine.translation(170, 10) * Affine.scale(0.1, -0.1)
+    pacific_geobox = GeoBox((200, 400), transform, epsg4326)  # 20° x 40°
+    
+    # Create tiles
+    tiles = GeoboxTiles(pacific_geobox, tile_shape=(50, 50))
+    
+    # Target in Web Mercator
+    mercator_transform = Affine.translation(18000000, 1000000) * Affine.scale(10000, -10000)
+    mercator_geobox = GeoBox((100, 200), mercator_transform, epsg3857)
+    mercator_tiles = GeoboxTiles(mercator_geobox, tile_shape=(25, 25))
+    
+    # This should work without GEOSException
+    intersections = tiles.grid_intersect(mercator_tiles)
+    assert isinstance(intersections, dict)
+
+


### PR DESCRIPTION
Fixes GEOSException when reprojecting data in sinusoidal projection that spans the antimeridian

**`odc/geo/geobox.py`:**
- Enhanced `GeoboxTiles.grid_intersect()` with error handling for antimeridian-spanning geometries
- Added `wrapdateline` parameter to `GeoBox.footprint()` method for antimeridian-aware geometry conversion

**`tests/antimeridian.py`:**
-Added antimeridian scenario

I tried the scenario in issue #147 and it seems to work? But couldn't figure out how to make it into a test, or if that's even desirable.