### PR TITLE
CI: cancel previous jobs on PR updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-wheels:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -36,6 +37,7 @@ jobs:
           retention-days: 1
 
   build-test-env-base:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -78,6 +80,7 @@ jobs:
           mamba env export -p /tmp/test_env
 
   run-black-check:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs:
       - build-test-env-base
@@ -102,6 +105,7 @@ jobs:
           black --check .
 
   run-pylint:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs:
       - build-test-env-base
@@ -131,6 +135,7 @@ jobs:
           pylint -v odc
 
   run-mypy:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs:
       - build-test-env-base
@@ -155,6 +160,7 @@ jobs:
           mypy --explicit-package-bases --python-version 3.10 odc
 
   test-with-coverage:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -207,6 +213,7 @@ jobs:
           use_oidc: true
 
   test-wheels:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     needs:
@@ -254,6 +261,7 @@ jobs:
           DASK_TEMPORARY_DIRECTORY: /tmp/dask
 
   check-docs:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
   push:
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-wheels:
     timeout-minutes: 15

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,6 +3,12 @@ name: Publish to PyPI
 on:
   workflow_dispatch:
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   publish-pypi:
     if: github.repository == 'opendatacube/odc-geo'

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish-pypi:
     if: github.repository == 'opendatacube/odc-geo'
-
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This avoids clogging the CI machines when one of the quick checks fail and you update the PR to fix that.

Also add a commit that shortens the job timeout in case someone hangs the CI machines.