### PR TITLE
Smarter handling of geojson in explore

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -142,6 +142,7 @@ Shapely geometry classes with CRS information attached.
    chop_along_antimeridian
    clip_lon180
    common_crs
+   count_coordinates
    densify
    intersects
    lonlat_bounds

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -883,9 +883,13 @@ class Geometry(SupportsCoords[float]):
         :param map_kwds:
             Additional keyword arguments to pass to :py:class:`folium.Map`.
         :param kwargs:
-            Additional keyword arguments to pass to :py:class:`folium.GeoJson`.
+            Additional keyword arguments to pass to :py:meth:`odc.geo.geom.Geometry.geojson`
+            and :py:class:`folium.GeoJson`.
 
         :return: A :py:mod:`folium` map containing the plotted Geometry.
+
+        :seealso: :py:meth:`odc.geo.geom.Geometry.geojson` for more details on
+            the parameters.
         """
         # pylint: disable=import-outside-toplevel, redefined-builtin
         have.check_or_error("folium")
@@ -898,9 +902,15 @@ class Geometry(SupportsCoords[float]):
 
         # Convert to GeoJSON with resolution based on approx 100
         # points per side for proper plotting/reprojection
-        bbox = self.boundingbox
-        res = max(bbox.span_x, bbox.span_y) / 100
-        geojson = self.geojson(resolution=res)
+        gj_args = {}
+        for k in ("simplify", "wrapdateline", "resolution"):
+            if k in kwargs:
+                gj_args[k] = kwargs.pop(k)
+
+        if "resolution" not in gj_args:
+            bbox = self.boundingbox
+            gj_args["resolution"] = max(bbox.span_x, bbox.span_y) / 100
+        geojson = self.geojson(**gj_args)
 
         # Create layer and add to map
         layer = GeoJson(data=geojson, **kwargs)

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -783,7 +783,7 @@ class Geometry(SupportsCoords[float]):
     def geojson(
         self,
         properties: Optional[Dict[str, Any]] = None,
-        simplify: float = 0.05,
+        simplify: float | Literal["auto"] = "auto",
         resolution: Optional[float] = None,
         wrapdateline: bool = False,
         **props,
@@ -791,22 +791,27 @@ class Geometry(SupportsCoords[float]):
         """
         Render geometry to GeoJSON.
 
-        Convert geometry to ``ESPG:4326`` and wrap it in GeoJSON Feature with supplied properties.
+        Convert geometry to ``ESPG:4326`` and wrap it in GeoJSON Feature with
+        supplied properties.
 
         :param properties:
             Properties to include in the GeoJSON output.
 
         :param simplify:
-            Tolerance in degrees for simplifying geometry after changing to lon/lat. Larger number
-            will result in a smaller (fewer points) and hence faster to display, but less precise
-            geometry. Default is ``0.05`` of a degree. To disable set to ``0``.
+            Tolerance in degrees for simplifying geometry after changing to
+            lon/lat. Larger number will result in a smaller (fewer points) and
+            hence faster to display, but less precise geometry. Default is
+            ``"auto"``, meaning no simplification for geometries with only few
+            points and ``0.05`` of a degree for geometries with many. To disable
+            set to ``0``.
 
         :param resolution:
-           When supplied, extra points will be added to the original geometry such that no segment
-           is longer than ``resolution`` units. Passed on to
-           :py:meth:`~odc.geo.geom.Geometry.to_crs`.
+           When supplied, extra points will be added to the original geometry
+           such that no segment is longer than ``resolution`` units. Passed on
+           to :py:meth:`~odc.geo.geom.Geometry.to_crs`.
 
-        :param wrapdateline: Passed on to :py:meth:`~odc.geo.geom.Geometry.to_crs`
+        :param wrapdateline: Passed on to
+            :py:meth:`~odc.geo.geom.Geometry.to_crs`
 
         :return: GeoJSON Feature dictionary
         """
@@ -832,7 +837,15 @@ class Geometry(SupportsCoords[float]):
         else:
             gg = self
 
-        if simplify > 0:
+        if simplify == "auto":
+            if count_coordinates(gg) < 100:
+                simplify = 0.0
+            else:
+                bbox = gg.boundingbox
+                simplify = min(0.05, max(bbox.span_x, bbox.span_y) / 100)
+
+        assert isinstance(simplify, (float, int))
+        if simplify > 0.0:
             gg = gg.simplify(simplify)
         if properties is None:
             properties = {**props}

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -26,6 +26,7 @@ from typing import (
 )
 
 import numpy
+import shapely
 from affine import Affine
 from pyproj.aoi import AreaOfInterest
 from shapely import geometry, ops
@@ -1470,6 +1471,36 @@ def mid_longitude(geom: Geometry) -> float:
     """
     ((lon,), _) = geom.centroid.to_crs("epsg:4326").xy
     return lon
+
+
+def count_coordinates(g: Geometry | Iterable[Geometry] | BoundingBox) -> int:
+    """
+    Count the number of coordinates in a geometry.
+
+    :param g:
+       Geometry, iterable of geometries, or bounding box to count coordinates for
+    :return:
+       Number of coordinates in the input geometry(ies)
+
+    Examples:
+        >>> point = geom.point(10, 20, crs="EPSG:4326")
+        >>> count_coordinates(point)
+        1
+        >>> line = geom.line([(0, 0), (1, 1), (2, 2)], crs="EPSG:4326")
+        >>> count_coordinates(line)
+        3
+        >>> bbox = geom.BoundingBox(0, 0, 10, 10, crs="EPSG:4326")
+        >>> count_coordinates(bbox)
+        4
+        >>> geometries = [point, line]
+        >>> count_coordinates(geometries)
+        4
+    """
+    if isinstance(g, Geometry):
+        return shapely.count_coordinates(g.geom)
+    if isinstance(g, BoundingBox):
+        return 4
+    return shapely.count_coordinates([_g.geom for _g in g])
 
 
 def _auto_resolution(g: Geometry) -> float:

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -16,6 +16,7 @@ from odc.geo.geobox import GeoBox, _round_to_res
 from odc.geo.geom import (
     chop_along_antimeridian,
     clip_lon180,
+    count_coordinates,
     densify,
     force_2d,
     multigeom,
@@ -1055,3 +1056,49 @@ def test_explore_geom(geom_json) -> None:
     geometry.explore(map=m_external)
     assert isinstance(m_external, Map)
     assert any(isinstance(child, GeoJson) for child in m_external._children.values())
+
+
+def test_count_coordinates() -> None:
+    """Test count_coordinates function with various input types."""
+    crs = epsg4326
+
+    # Test with Geometry (Point)
+    point = geom.point(10, 20, crs)
+    assert count_coordinates(point) == 1
+
+    # Test with Geometry (LineString)
+    line = geom.line([(0, 0), (1, 1), (2, 2)], crs)
+    assert count_coordinates(line) == 3
+
+    # Test with Geometry (Polygon)
+    polygon = geom.polygon([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)], crs)
+    assert count_coordinates(polygon) == 5
+
+    # Test with Geometry (MultiPoint)
+    multi_point = geom.multipoint([(0, 0), (1, 1), (2, 2)], crs)
+    assert count_coordinates(multi_point) == 3
+
+    # Test with BoundingBox
+    bbox = geom.BoundingBox(0, 0, 10, 10, crs)
+    assert count_coordinates(bbox) == 4
+
+    # Test with Iterable[Geometry]
+    geometries = [point, line, polygon]
+    assert count_coordinates(geometries) == 9  # 1 + 3 + 5
+
+    # Test with empty list
+    assert count_coordinates([]) == 0
+
+    # Test with single geometry in list
+    assert count_coordinates([point]) == 1
+
+    # Test with complex geometry (MultiPolygon)
+    multi_polygon = geom.multipolygon(
+        [
+            [[(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]],
+            [[(2, 2), (3, 2), (3, 3), (2, 3), (2, 2)]],
+        ],
+        crs,
+    )
+    # MultiPolygon with 2 polygons, each with 5 coordinates
+    assert count_coordinates(multi_polygon) == 10


### PR DESCRIPTION
* Automatic computation of `simplify` argument in `Geometry.geojson`
  * don't simplify small geometries (fewer than 100 nodes)
  * Use 1% of the largest span of the geometry in lonlat OR 0.05 degrees, whichever is smallest
* Pass through all `.geojson` parameters from `.explore` (`resolution`, `wrapdateline` and `simplify`) 
* expose `shapely.count_coordinates`


Closes #240 