### PR TITLE
Avoid passing mpu_kwargs to create_multipart_upload

### DIFF
--- a/odc/geo/cog/_s3.py
+++ b/odc/geo/cog/_s3.py
@@ -4,6 +4,7 @@ S3 utils for COG to S3.
 
 from __future__ import annotations
 
+import inspect
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -110,11 +111,16 @@ class S3MultiPartUpload(S3Limits, MultiPartUploadBase):
             aws_session_token=creds.token,
         )
 
-    def initiate(self) -> str:
+    def initiate(self, **kw) -> str:
         """Initiate the S3 multipart upload."""
         assert self.uploadId == ""
         s3 = self.s3_client()
-        rr = s3.create_multipart_upload(Bucket=self.bucket, Key=self.key)
+
+        # Filter kwargs to only include valid parameters for create_multipart_upload
+        valid_params = set(inspect.signature(s3.create_multipart_upload).parameters.keys())
+        filtered_kw = {k: v for k, v in kw.items() if k in valid_params}
+
+        rr = s3.create_multipart_upload(Bucket=self.bucket, Key=self.key, **filtered_kw)
         self.uploadId = rr["UploadId"]
         return self.uploadId
 
@@ -253,7 +259,7 @@ class DelayedS3Writer(S3Limits):
             # Assume running locally with everyone sharing same self.mpu
             with _mpu_local_lock():
                 if not final_write:
-                    _ = mpu.initiate()
+                    _ = mpu.initiate(**self.kw)
                 return mpu
 
         from distributed import Lock as DLock
@@ -278,7 +284,7 @@ class DelayedS3Writer(S3Limits):
             # 1. Start upload
             # 2. Share UploadId with others
             if not final_write:
-                _ = mpu.initiate()
+                _ = mpu.initiate(**self.kw)
                 shared_state.set(mpu.uploadId)
 
         assert mpu.started or final_write

--- a/odc/geo/cog/_s3.py
+++ b/odc/geo/cog/_s3.py
@@ -117,10 +117,10 @@ class S3MultiPartUpload(S3Limits, MultiPartUploadBase):
         s3 = self.s3_client()
 
         # Filter kwargs to only include valid parameters for create_multipart_upload
-        valid_params = set(inspect.signature(s3.create_multipart_upload).parameters.keys())
-        filtered_kw = {k: v for k, v in kw.items() if k in valid_params}
+        s3_params = set(inspect.signature(s3.create_multipart_upload).parameters.keys())
+        s3_kw = {k: v for k, v in kw.items() if k in s3_params}
 
-        rr = s3.create_multipart_upload(Bucket=self.bucket, Key=self.key, **filtered_kw)
+        rr = s3.create_multipart_upload(Bucket=self.bucket, Key=self.key, **s3_kw)
         self.uploadId = rr["UploadId"]
         return self.uploadId
 

--- a/odc/geo/cog/_s3.py
+++ b/odc/geo/cog/_s3.py
@@ -110,11 +110,11 @@ class S3MultiPartUpload(S3Limits, MultiPartUploadBase):
             aws_session_token=creds.token,
         )
 
-    def initiate(self, **kw) -> str:
+    def initiate(self) -> str:
         """Initiate the S3 multipart upload."""
         assert self.uploadId == ""
         s3 = self.s3_client()
-        rr = s3.create_multipart_upload(Bucket=self.bucket, Key=self.key, **kw)
+        rr = s3.create_multipart_upload(Bucket=self.bucket, Key=self.key)
         self.uploadId = rr["UploadId"]
         return self.uploadId
 
@@ -253,7 +253,7 @@ class DelayedS3Writer(S3Limits):
             # Assume running locally with everyone sharing same self.mpu
             with _mpu_local_lock():
                 if not final_write:
-                    _ = mpu.initiate(**self.kw)
+                    _ = mpu.initiate()
                 return mpu
 
         from distributed import Lock as DLock
@@ -278,7 +278,7 @@ class DelayedS3Writer(S3Limits):
             # 1. Start upload
             # 2. Share UploadId with others
             if not final_write:
-                _ = mpu.initiate(**self.kw)
+                _ = mpu.initiate()
                 shared_state.set(mpu.uploadId)
 
         assert mpu.started or final_write


### PR DESCRIPTION
Fixes https://github.com/opendatacube/odc-geo/issues/251

In https://github.com/opendatacube/odc-geo/commit/fab60119b521f0112f8ace119d4422fc76c37644, the S3 multipart-upload was changed. This meant that the writer was passed the result of `get_mpu_kwargs`, rather than the remaining kwargs passed to `upload`. This, in turn, meant that the writer was passing the result of `get_mpu_kwargs` when calling `initiate`, leading to them being passed to S3 API call.

This PR prevents the result of `get_mpu_kwargs` from being passed to `initiate`, fixing the S3 API call