### PR TITLE
geom: catch shapely exceptions

### DIFF
--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -1277,7 +1277,7 @@ def polygon_from_transform(
     Useful for computing footprints of a geo-registered raster images.
 
     :param shape: Shape of the raster in pixels
-    :param transform: Affine transfrom from pixel to CRS units
+    :param transform: Affine transform from pixel to CRS units
     :param crs: CRS
     """
     x1, y1 = shape_(shape).xy

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -31,6 +31,7 @@ from affine import Affine
 from pyproj.aoi import AreaOfInterest
 from shapely import geometry, ops
 from shapely.coords import CoordinateSequence
+from shapely.errors import GEOSException
 from shapely.geometry import base
 
 from ._interop import have
@@ -518,7 +519,10 @@ class Geometry(SupportsCoords[float]):
         if isinstance(geom, base.BaseGeometry):
             self.geom = geom
         elif isinstance(geom, dict):
-            self.geom = _geojson_to_shapely(geom)
+            try:
+                self.geom = _geojson_to_shapely(geom)
+            except GEOSException as e:
+                raise ValueError(e) from None
         else:
             raise ValueError(f"Unexpected type {type(geom)}")
 

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -88,6 +88,11 @@ def test_props() -> None:
     # constructor with bad input should raise ValueError
     with pytest.raises(ValueError):
         geom.Geometry(object())
+    with pytest.raises(ValueError):  # Do not leak shapely exceptions.
+        geom.polygon(
+            [(np.nan, np.nan), (np.nan, np.nan), (np.nan, np.nan), (np.nan, np.nan)],
+            crs=epsg3857,
+        )
 
 
 def test_tests() -> None:


### PR DESCRIPTION
Catch shapely exceptions and convert
them to ValueErrors so callers do
not have to worry about catching
shapely exceptions.