### PR TITLE
Use Ruff instead of black+isort

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,33 +89,6 @@ jobs:
         run: |
           mamba env export -p /tmp/test_env
 
-  run-black-check:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    needs:
-      - build-test-env-base
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-      - name: Get Conda Environment from Cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        id: conda_cache
-        with:
-          path: /tmp/test_env
-          key: ${{ runner.os }}-test-env-py310-${{ hashFiles('tests/test-env-py310.yml') }}
-
-      - name: Update PATH
-        shell: bash
-        run: |
-          echo "/tmp/test_env/bin" >> $GITHUB_PATH
-
-      - name: Check formatting (black)
-        shell: bash
-        run: |
-          black --check .
-
   run-pylint:
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -182,7 +155,6 @@ jobs:
       id-token: write
     needs:
       - build-test-env-base
-      - run-black-check
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -236,7 +208,6 @@ jobs:
 
     needs:
       - build-test-env-base
-      - run-black-check
       - build-wheels
 
     steps:
@@ -286,7 +257,6 @@ jobs:
 
     needs:
       - build-test-env-base
-      - run-black-check
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,12 @@ repos:
         - id: trailing-whitespace
         - id: check-added-large-files
         - id: check-merge-conflict
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.15.12
+      hooks:
+      - id: ruff-check
+        args: [--fix, --show-fixes, --output-format, grouped]
+      - id: ruff-format
     - repo: https://github.com/astral-sh/uv-pre-commit
       rev: 0.11.13
       hooks:

--- a/dev-env.yml
+++ b/dev-env.yml
@@ -24,11 +24,10 @@ dependencies:
   ## linting tools
   - autopep8
   - autoflake
-  - black >=25.1
-  - isort
   - mypy
   - pycodestyle
   - pylint =3
+  - ruff
   - docutils
 
   ## test

--- a/developer.md
+++ b/developer.md
@@ -16,7 +16,7 @@ pip install -e .
 
 ```json
 {
-    "python.formatting.provider": "black",
+    "python.formatting.provider": "ruff",
     "python.linting.flake8Enabled": true,
     "python.linting.flake8Args": [
         "--ignore=E731,W503",

--- a/odc/geo/_blocks.py
+++ b/odc/geo/_blocks.py
@@ -64,7 +64,7 @@ class BlockAssembler:
             if state is None:
                 if b.ndim < axis + 2:
                     raise ValueError(
-                        f"Too few dimensions for `axis={axis}` ({b.ndim} < {axis+2})"
+                        f"Too few dimensions for `axis={axis}` ({b.ndim} < {axis + 2})"
                     )
                 state = (b.ndim, b.shape[:axis], b.shape[axis + 2 :])
 

--- a/odc/geo/cog/_s3.py
+++ b/odc/geo/cog/_s3.py
@@ -15,10 +15,9 @@ from ._multipart import MultiPartUploadBase
 
 if TYPE_CHECKING:
     import dask.bag
+    import distributed
     from botocore.credentials import ReadOnlyCredentials
     from dask.delayed import Delayed
-
-    import distributed
 
 _state: dict[str, Any] = {}
 

--- a/odc/geo/cog/_tifffile.py
+++ b/odc/geo/cog/_tifffile.py
@@ -9,16 +9,15 @@ Write Cloud Optimized GeoTIFFs from xarrays.
 from __future__ import annotations
 
 import itertools
+import math
 from functools import partial
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from urllib.parse import urlparse
 from xml.sax.saxutils import escape as xml_escape
 
-import math
 import numpy as np
 import xarray as xr
-
 
 from .._interop import have
 from ..geobox import GeoBox
@@ -27,7 +26,6 @@ from ..types import Shape2d, SomeNodata, Unset, shape_
 from ._mpu import mpu_write
 from ._mpu_fs import MPUFileSink
 from ._multipart import MultiPartUploadBase
-
 from ._shared import (
     GDAL_COMP,
     GEOTIFF_TAGS,

--- a/odc/geo/crs.py
+++ b/odc/geo/crs.py
@@ -409,6 +409,7 @@ class CRSMismatchError(ValueError):
 SomeCRS = Union[str, int, CRS, _CRS, Dict[str, Any]]
 MaybeCRS = Union[SomeCRS, Unset, None]
 
+
 # fmt: off
 @overload
 def norm_crs(crs: SomeCRS) -> CRS: ...

--- a/odc/geo/ui.py
+++ b/odc/geo/ui.py
@@ -116,7 +116,7 @@ def svg_base_map(
     if target is not None:
         target_x, target_y = target
         more_svg += (
-            f'<path stroke="{stroke}" stroke-width="{stroke_width}" stroke-opacity="{stroke_opacity*0.8}"'
+            f'<path stroke="{stroke}" stroke-width="{stroke_width}" stroke-opacity="{stroke_opacity * 0.8}"'
             f' d="M{target_x},{target_y} V90zV-90zH180zH-180z"/>'
         )
 
@@ -127,7 +127,7 @@ def svg_base_map(
      width="{w:d}" height="{h:d}"
      viewBox="0 0 {w:d} {h:d}"
      preserveAspectRatio="xMinYMin meet">
-<g transform="matrix({s},0,0,{-s},{-x0*s},{y1*s})">
+<g transform="matrix({s},0,0,{-s},{-x0 * s},{y1 * s})">
 <path fill-rule="evenodd"
   fill="{fill}"
   opacity="{opacity}"
@@ -168,7 +168,7 @@ def make_svg(
      width="{w:d}" height="{h:d}"
      viewBox="0 0 {w:d} {h:d}"
      preserveAspectRatio="xMinYMin meet">
-<g transform="matrix({s},0,0,{-s},{-x0*s},{y1*s})">
+<g transform="matrix({s},0,0,{-s},{-x0 * s},{y1 * s})">
 {more_svg}
 </g></svg>"""
 
@@ -212,7 +212,7 @@ class PixelGridDisplay:
 
         grid_svg = (
             '<path fill="none" opacity="0.8"'
-            f' stroke-width="{0.8*scale_factor}"'
+            f' stroke-width="{0.8 * scale_factor}"'
             f' stroke="{grid_stroke}"'
             f' d="{grids.svg_path()}" />'
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ exclude_lines = [
   "^ *\\.\\.\\.$",
 ]
 
-[tool.isort]
-profile = "black"
-
 [tool.pylint.messages_control]
 
 max-line-length = 120
@@ -94,6 +91,11 @@ disable = [
   "unsubscriptable-object",
 ]
 
+[tool.ruff.lint]
+select = [
+    "I",  # Isort
+]
+
 [dependency-groups]
 dev = [
     "azure-storage-blob>=12.25.0",
@@ -109,6 +111,7 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest-timeout>=2.3.1",
     "rasterio>=1.4.3",
+    "ruff",
     "tifffile>=2024.8.30",
     "xarray>=0.19",
     "laspy>=2.5.4",

--- a/tests/test-env-py310.yml
+++ b/tests/test-env-py310.yml
@@ -20,11 +20,10 @@ dependencies:
   ## linting tools
   - autopep8
   - autoflake
-  - black >=25.1.0
-  - isort
   - mypy
   - pycodestyle
   - pylint =3
+  - ruff
   - types-cachetools
   - types-certifi
 

--- a/tests/test_az.py
+++ b/tests/test_az.py
@@ -2,6 +2,7 @@
 
 import base64
 from unittest.mock import MagicMock
+
 import pytest
 
 pytest.importorskip("azure.storage.blob")

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,8 +1,8 @@
+from collections.abc import Iterable
 from typing import Tuple
 
 import numpy as np
 import pytest
-from collections.abc import Iterable
 
 from odc.geo import SomeIndex2d
 from odc.geo._blocks import BlockAssembler

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -1,7 +1,7 @@
 import itertools
 from io import BytesIO
 from pathlib import Path
-from typing import Sequence, Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 import numpy as np
 import pytest

--- a/tests/test_gbox_ops.py
+++ b/tests/test_gbox_ops.py
@@ -135,6 +135,6 @@ def test_gbox_ops() -> None:
     assert d.shape == s.shape
     assert d.extent != s.extent
     np.testing.assert_almost_equal(d.extent.area, s.extent.area, 5)
-    assert s[49:52, 499:502].extent.contains(
-        d[50:51, 500:501].extent
-    ), "Check that center pixel hasn't moved"
+    assert s[49:52, 499:502].extent.contains(d[50:51, 500:501].extent), (
+        "Check that center pixel hasn't moved"
+    )

--- a/tests/test_las.py
+++ b/tests/test_las.py
@@ -8,7 +8,8 @@ from odc.geo.io import load_las
 pytest.importorskip("laspy")
 pytest.importorskip("lazrs")
 
-test_crss = {"autzen": """
+test_crss = {
+    "autzen": """
 COMPOUNDCRS["NAD83 / Oregon GIC Lambert (ft) + NAVD88 height (ftUS)",
     PROJCRS["NAD83 / Oregon GIC Lambert (ft)",
         BASEGEOGCRS["NAD83",
@@ -53,7 +54,8 @@ COMPOUNDCRS["NAD83 / Oregon GIC Lambert (ft) + NAVD88 height (ftUS)",
             AXIS["gravity-related height",up,
                 LENGTHUNIT["US survey foot",0.304800609601219]],
         ID["EPSG",6360]]]
-"""}
+"""
+}
 
 AUTZEN_DATA_VARS = (
     "user_data",

--- a/uv.lock
+++ b/uv.lock
@@ -1973,6 +1973,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "rasterio", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ruff" },
     { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "types-cachetools" },
@@ -2025,6 +2026,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "rasterio", specifier = ">=1.4.3" },
+    { name = "ruff" },
     { name = "tifffile", specifier = ">=2024.8.30" },
     { name = "types-cachetools" },
     { name = "xarray", specifier = ">=0.19" },
@@ -2850,6 +2852,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace black and isort with Ruff,
and reformat to make Ruff happy.

I'm personally not a fan of pre-commit,
but since that is already used for other
formatting we put the Ruff modules in
there to get the CI to do formatting checks.
