### PR TITLE
Use SCM for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ cython_debug/
 docs/_api/
 tt.py
 tt_*py
+odc/geo/_version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+prune docs
+prune tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "odc-geo"
 description = "Geometry Classes and Operations (opendatacube)"
-version = "0.5.1"
+dynamic = ["version"]
 authors = [
     {name = "Open Data Cube"},
 ]
@@ -50,11 +50,16 @@ las = ["laspy", "lazrs"]
 all = ["rasterio", "tifffile", "imagecodecs", "dask[array,distributed]", "boto3", "azure-storage-blob", "laspy", "lazrs"]
 
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools>=69", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
 
-[tool.flit.module]
-name = "odc.geo"
+[tool.setuptools.packages.find]
+exclude = ["tests"]
+include = ["odc*"]
+
+[tool.setuptools_scm]
+write_to = "odc/geo/_version.py"
+fallback_version = "0.5.2.dev0"
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ las = ["laspy", "lazrs"]
 all = ["rasterio", "tifffile", "imagecodecs", "dask[array,distributed]", "boto3", "azure-storage-blob", "laspy", "lazrs"]
 
 [build-system]
-requires = ["setuptools>=69", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=69", "setuptools_scm[toml]>=8,<10"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,10 @@ authors = [
 maintainers = [
     {name = "Open Data Cube"},
 ]
-license = {text = "Apache License 2.0"}
+license = "Apache-2.0"
 readme = "README.rst"
 keywords = ["gis", "geospatial", "opendatacube"]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",

--- a/uv.lock
+++ b/uv.lock
@@ -1902,7 +1902,6 @@ wheels = [
 
 [[package]]
 name = "odc-geo"
-version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "affine" },


### PR DESCRIPTION
Follows the pattern of other repos, such as `odc-loader` to use git tags for releases.