### PR TITLE
Accept Path destinations in save_cog_with_dask

### DIFF
--- a/odc/geo/cog/_tifffile.py
+++ b/odc/geo/cog/_tifffile.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import itertools
 import math
+import os
 from functools import partial
 from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from urllib.parse import urlparse
 from xml.sax.saxutils import escape as xml_escape
@@ -619,7 +621,7 @@ def _gdal_sample_descriptions(descriptions: list[str]) -> list[str]:
 
 def save_cog_with_dask(
     xx: xr.DataArray,
-    dst: str = "",
+    dst: Union[str, Path] = "",
     *,
     compression: Union[str, Unset] = Unset(),
     compressionargs: Any = None,
@@ -659,7 +661,7 @@ def save_cog_with_dask(
       it's set to merge up to four of the highest overview layers.
 
     :param xx: Pixels as :py:class:`xarray.DataArray` backed by Dask.
-    :param dst: S3, Azure URL, or file path.
+    :param dst: S3, Azure URL, or file path (``str`` or :py:class:`~pathlib.Path`).
     :param compression: Compression to use, default is ``DEFLATE``.
     :param level: Compression “level”, depends on chosen compression.
     :param predictor: TIFF predictor setting.
@@ -686,6 +688,9 @@ def save_cog_with_dask(
     import dask.bag
 
     from ..xr import ODCExtensionDa
+
+    # Accept Path objects; everything downstream (urlparse, sinks) expects str
+    dst = os.fspath(dst)
 
     aws = aws or {}
     azure = azure or {}

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -470,6 +470,17 @@ def test_band_names(gbox: GeoBox) -> None:
     assert _band_names(img) == ["red", "green", "blue", "alpha"]
 
 
+def test_cog_with_dask_path_dst(gbox: GeoBox, tmp_path: Path) -> None:
+    # dst as a Path object used to crash with AttributeError (issue #239)
+    gbox = gbox.zoom_to(256)
+    img = xr_zeros(gbox, "int16", chunks=(128, 128), nodata=-9999)
+    fname = tmp_path / "cog.tif"
+    fut = save_cog_with_dask(img, fname, compression="deflate", level=2)
+    rr = fut.compute()
+    assert str(rr) == str(fname)
+    assert fname.exists()
+
+
 @pytest.mark.parametrize("dtype", ["int16", "float32"])
 def test_cog_with_dask_smoke_test(gbox: GeoBox, tmp_path: Path, dtype) -> None:
     gbox = gbox.zoom_to(1024)


### PR DESCRIPTION
Fixes #239.

`save_cog_with_dask(xx, Path("out.tif"))` crashed with `AttributeError: 'PosixPath' object has no attribute 'decode'` from `urlparse`. The destination is now normalized with `os.fspath` at function entry, so `Path` objects work the same as string paths — consistent with `write_cog`, which already accepts `Union[str, Path]`. Cloud URLs are unaffected (strings pass through `os.fspath` unchanged), and any other `os.PathLike` resolves to its filesystem path. Added a regression test that fails with the old AttributeError.