### PR TITLE
Fix doc build

### DIFF
--- a/docs/raster-tools.rst
+++ b/docs/raster-tools.rst
@@ -51,7 +51,7 @@ Plotting on a map
       # Make some sample images
       def gen_sample(iso3, crs="epsg:3857", res=60_000, vmin=0, vmax=1000):
          xx = rasterize(country_geom(iso3, crs), res)
-         return xr.where(xx, uniform(vmin, vmax, size=xx.shape), float("nan")).astype("float32")
+         return xx.where(uniform(vmin, vmax, size=xx.shape), float("nan")).astype("float32")
 
       aus, png, nzl = [gen_sample(iso3) for iso3 in ["AUS", "PNG", "NZL"]]
 


### PR DESCRIPTION
Change the documentation to refer
to where on the object instead
of passing the object as a parameter.
This makes xx.odc.geobox.crs
into non-None, so the assert on
native_crs not being None in
_map.py:135 passes.

Idea picked up from the conftest.py
change in #268.