### PR TITLE
Don't lose tiles when projecting a large query into a limited-area CRS

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -147,6 +147,7 @@ Shapely geometry classes with CRS information attached.
    intersects
    lonlat_bounds
    mid_longitude
+   project_to_extent
    projected_lon
    sides
 

--- a/odc/geo/geobox.py
+++ b/odc/geo/geobox.py
@@ -27,7 +27,13 @@ from affine import Affine
 
 from . import geom
 from .crs import CRS, MaybeCRS, SomeCRS, norm_crs
-from .geom import BoundingBox, Geometry, bbox_intersection, bbox_union
+from .geom import (
+    BoundingBox,
+    Geometry,
+    bbox_intersection,
+    bbox_union,
+    project_to_extent,
+)
 from .math import (
     clamp,
     extract_anchor,
@@ -681,7 +687,9 @@ class GeoBox(GeoBoxBase):
         if crs is None or isinstance(crs, Unset):
             crs = geopolygon.crs
         else:
-            geopolygon = geopolygon.to_crs(crs)
+            # densify, else the bounding box of the projected corners can be smaller
+            # than the projected polygon and the geobox crops it (odc-geo#87)
+            geopolygon = geopolygon.to_crs(crs, resolution="auto")
 
         return GeoBox.from_bbox(
             geopolygon.boundingbox,
@@ -1444,7 +1452,12 @@ class GeoboxTiles:
         """
 
         if bbox.crs is not None:
-            bbox = self._gbox.project(bbox.polygon).boundingbox
+            poly = bbox.polygon
+            if bbox.crs != self._gbox.crs:
+                poly = project_to_extent(poly, self._gbox.extent)
+                if poly.is_empty:
+                    return range(0), range(0)
+            bbox = self._gbox.project(poly).boundingbox
 
         def _clamp(span: Tuple[float, float], N: int):
             a1, a2 = span
@@ -1479,7 +1492,9 @@ class GeoboxTiles:
             poly = query
 
         if target_crs is not None and poly.crs != target_crs:
-            poly = poly.to_crs(target_crs, check_and_fix=True)
+            poly = project_to_extent(poly, self._gbox.extent)
+            if poly.is_empty:
+                return
 
         yy, xx = self.range_from_bbox(poly.boundingbox)
         for idx in itertools.product(yy, xx):

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -458,10 +458,16 @@ def densify(
     """
     Adds points so they are at most `resolution` units apart.
     """
+    if len(coords) == 0:
+        return []
+    if not resolution > 0:
+        # nothing to add, and the loop below would never terminate
+        return [cast(Tuple[float, float], p) for p in coords]
+
     d2 = resolution**2
 
     def short_enough(p1, p2):
-        return (p1[0] ** 2 + p2[0] ** 2) < d2
+        return ((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2) < d2
 
     new_coords: List[Tuple[float, float]] = [cast(Tuple[float, float], coords[0])]
     for p1, p2 in zip(coords[:-1], coords[1:]):
@@ -1532,4 +1538,10 @@ def count_coordinates(g: Geometry | Iterable[Geometry] | BoundingBox) -> int:
 
 def _auto_resolution(g: Geometry) -> float:
     # aim for ~100 points per side of a square
-    return math.sqrt(g.area) * 4 / 100
+    res = math.sqrt(g.area) * 4 / 100
+    if res > 0:
+        return res
+    # zero-area inputs (lines, degenerate polygons) still need densifying,
+    # fall back to the extent
+    bbox = g.boundingbox
+    return max(bbox.span_x, bbox.span_y) / 25

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -1498,6 +1498,55 @@ def lonlat_bounds(
     return BoundingBox.from_xy(xx_range, bbox.range_y, crs=4326)
 
 
+def _projects_cleanly(geom: Geometry) -> bool:
+    """Did a projection produce a usable shape, or did it fall apart?"""
+    if geom.is_empty:
+        return False
+    return geom.is_valid and all(math.isfinite(v) for v in geom.boundingbox.bbox)
+
+
+def project_to_extent(geom: Geometry, extent: Geometry) -> Geometry:
+    """
+    Project ``geom`` into the CRS of ``extent``, robust to ``geom`` being large.
+
+    Transforming the vertices of a geometry and taking the result at face value only
+    works while the transform is near-affine over the geometry: straight edges become
+    chords of the real, curved ones, and vertices outside the destination's domain land
+    somewhere arbitrary or not at all. For a query spanning much of the globe the
+    outcome can miss ``extent`` entirely (odc-geo#87).
+
+    Densifying fixes the chords. Where the destination cannot represent the input at
+    all, ``geom`` is first clipped to ``extent``, which is lossless for callers that
+    only want the overlap with ``extent`` anyway. Some inputs have no faithful image at
+    all -- a lon/lat box wrapping past the destination's antimeridian, or one covering a
+    pole -- and for those the whole of ``extent`` is returned, so callers over-select
+    rather than silently lose the overlap.
+
+    :param geom: Geometry in any CRS
+    :param extent: Region of interest, in the destination CRS
+    :return: ``geom`` in the CRS of ``extent``, empty only when there is no overlap
+    """
+    if geom.crs is None or extent.crs is None:
+        raise ValueError("Both geometries need a CRS")
+    if geom.crs == extent.crs:
+        return geom
+
+    clip = extent.to_crs(geom.crs, resolution="auto")
+    if _projects_cleanly(clip):
+        clipped = geom & clip
+        if clipped.is_empty:
+            return Geometry(clipped.geom, extent.crs)
+    else:
+        # ``extent`` has no faithful image in the source CRS either, so there is
+        # nothing to clip against
+        clipped = geom
+
+    out = clipped.to_crs(extent.crs, resolution="auto", check_and_fix=True)
+    if _projects_cleanly(out):
+        return out
+    return extent
+
+
 def mid_longitude(geom: Geometry) -> float:
     """
     Compute longitude of the center point of a geometry.

--- a/odc/geo/gridspec.py
+++ b/odc/geo/gridspec.py
@@ -218,7 +218,7 @@ class GridSpec:
           Optional cache to re-use geoboxes instead of creating new one each turn: iterator of grid
           cells with :py:class:`odc.geo.geobox.GeoBox` tiles
         """
-        geopolygon = geopolygon.to_crs(self.crs, check_and_fix=True)
+        geopolygon = geopolygon.to_crs(self.crs, resolution="auto", check_and_fix=True)
         bbox = geopolygon.boundingbox
 
         for tile_index, tile_geobox in self.tiles(bbox, geobox_cache):

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -733,3 +733,17 @@ def test_shape(shape, allowed) -> None:
 )
 def test_geobox_anchor(gbox, expected_anchor) -> None:
     assert gbox.anchor == expected_anchor
+
+
+def test_from_geopolygon_cross_projection() -> None:
+    # the geobox has to cover the polygon it was built from, and the bounding box of
+    # the projected corners can be smaller than the projected polygon (#87)
+    aus = geom.box(100, -45, 160, -10, "epsg:4326")
+    gbox = GeoBox.from_geopolygon(aus, resolution=10_000, crs="epsg:3577")
+
+    footprint = aus.to_crs("epsg:3577", resolution=0.05, check_and_fix=True)
+    assert gbox.extent.contains(footprint)
+
+    # no reprojection, no change
+    same = GeoBox.from_geopolygon(aus, resolution=0.1)
+    assert same == GeoBox.from_geopolygon(aus, resolution=0.1, crs="epsg:4326")

--- a/tests/test_geoboxtiles.py
+++ b/tests/test_geoboxtiles.py
@@ -156,3 +156,75 @@ def test_gbox_tiles_roi(use_chunks) -> None:
         _idx = list(tt.tiles(bbox))
         assert len(_idx) == 1
         assert _idx[0] == idx
+
+
+# Grids in CRSs that only cover part of the planet, plus web mercator as a control
+# where projecting from lon/lat is already exact.
+LIMITED_AREA_GRIDS = [
+    ("epsg:3577", (-2e6, -5e6, 2.2e6, -1e6), 1_000),  # Australian Albers
+    ("epsg:32755", (0, 6e6, 8e5, 7e6), 1_000),  # UTM 55S
+    ("epsg:2193", (1e6, 4.7e6, 2.1e6, 6.2e6), 5_000),  # NZTM
+    ("epsg:5070", (-2.4e6, 2.5e5, 2.3e6, 3.2e6), 5_000),  # CONUS Albers
+    ("epsg:3413", (-3e6, -3e6, 3e6, 3e6), 20_000),  # NSIDC polar north
+    ("epsg:3857", (-2e7, -1e7, 2e7, 1e7), 40_000),  # control
+]
+
+
+def _grid(crs, bbox, resolution):
+    return GeoboxTiles(GeoBox.from_bbox(bbox, crs, resolution=resolution), (100, 100))
+
+
+def _nested_queries(gbt, n=6):
+    """Chain of lon/lat boxes growing from the grid's own footprint out to the world."""
+    b = gbt.base.footprint("epsg:4326").boundingbox
+    inner = (b.left, b.bottom, b.right, b.top)
+    outer = (-180, -90, 180, 90)
+    for i in range(n):
+        t = i / (n - 1)
+        yield geom.box(*(a + (z - a) * t for a, z in zip(inner, outer)), "epsg:4326")
+
+
+@pytest.mark.parametrize("crs, bbox, resolution", LIMITED_AREA_GRIDS)
+def test_tiles_cross_projection_monotonic(crs, bbox, resolution) -> None:
+    # A subset query can never select tiles a superset query misses. Projecting only
+    # the corners of a query broke this badly enough to return nothing at all for a
+    # global input (#87).
+    gbt = _grid(crs, bbox, resolution)
+    queries = list(_nested_queries(gbt))
+
+    prev = set(gbt.tiles(queries[0]))
+    assert len(prev) > 0
+    for inner, outer in zip(queries[:-1], queries[1:]):
+        assert inner.within(outer)
+        got = set(gbt.tiles(outer))
+        assert set(gbt.tiles(inner)) <= got, (crs, outer.boundingbox)
+        prev = got
+
+    # the grid's own footprint, and anything containing it, selects every tile
+    all_tiles = set(np.ndindex(gbt.shape.yx))
+    assert prev == all_tiles
+    assert set(gbt.tiles(geom.box(-180, -90, 180, 90, "epsg:4326"))) == all_tiles
+    assert gbt.range_from_bbox(geom.BoundingBox(-180, -90, 180, 90, "epsg:4326")) == (
+        range(gbt.shape[0]),
+        range(gbt.shape[1]),
+    )
+
+
+def test_tiles_global_query_australian_albers() -> None:
+    # the case from #87, with numbers: the grid is entirely inside the world box, so a
+    # world query has to return all of it
+    gbt = _grid(*LIMITED_AREA_GRIDS[0])
+    assert gbt.shape == (40, 42)
+
+    assert len(list(gbt.tiles(geom.box(-180, -90, 180, 90, "epsg:4326")))) == 1680
+    assert len(list(gbt.tiles(geom.box(-180, -60, 180, 10, "epsg:4326")))) == 1680
+
+    # a continent-sized query is not exempt either: the north edge of this box cuts
+    # through the top row of the grid, and every tile it touches must come back
+    aus = geom.box(100, -45, 160, -10, "epsg:4326")
+    assert (0, 7) in set(gbt.tiles(aus))
+
+    # controls: a query inside the safe region is untouched, and one on the other side
+    # of the planet still selects nothing
+    assert len(list(gbt.tiles(geom.box(130, -30, 140, -20, "epsg:4326")))) == 132
+    assert list(gbt.tiles(geom.box(-80, 20, -70, 30, "epsg:4326"))) == []

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -401,6 +401,41 @@ def test_densify() -> None:
     assert densify(s_x10, 5) == [(0, 0), (5, 0), (10, 0)]
     assert densify(s_x10, 4) == [(0, 0), (4, 0), (8, 0), (10, 0)]
 
+    # the "is this segment already short enough" test has to measure the segment, a
+    # long one is not exempt just because its endpoints sit near x=0
+    for coords in (
+        [(0.1, -80.0), (0.1, 80.0)],
+        [(50.0, -80.0), (50.0, 80.0)],
+        [(-80.0, 0.1), (80.0, 0.1)],
+        [(0.0, 0.0), (0.0, 5.0), (10.0, 5.0)],
+    ):
+        pts = densify(coords, 10)
+        assert max(math.dist(a, b) for a, b in zip(pts[:-1], pts[1:])) <= 10 + 1e-9
+
+    # no positive step means nothing can be added, and used to spin forever
+    assert densify(s_x10, 0) == s_x10
+    assert densify(s_x10, -1) == s_x10
+    assert densify([], 1) == []
+
+
+def test_segmented_zero_area() -> None:
+    # resolution="auto" was derived from area, which is 0 for anything 1-D, and a
+    # zero step never terminated
+    ll = geom.line([(0.0, -80.0), (0.0, 80.0)], epsg4326)
+    assert len(ll.segmented(10).geom.coords) == 17
+    assert len(ll.to_crs(epsg3857, resolution="auto").geom.coords) > 2
+
+    sliver = geom.polygon([(1, 1), (2, 2), (3, 3), (1, 1)], crs=epsg4326)
+    assert sliver.to_crs(epsg3857, resolution="auto").is_empty is False
+
+    pt = geom.point(10, 20, epsg4326)
+    assert pt.to_crs(epsg3857, resolution="auto").geom.geom_type == "Point"
+    assert (
+        geom.Geometry({"type": "Polygon", "coordinates": []}, epsg4326)
+        .to_crs(epsg3857, resolution="auto")
+        .is_empty
+    )
+
 
 def test_unary_union() -> None:
     box1 = geom.box(10, 10, 30, 30, crs=epsg4326)

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -437,6 +437,29 @@ def test_segmented_zero_area() -> None:
     )
 
 
+def test_project_to_extent() -> None:
+    extent = geom.box(-2_000_000, -5_000_000, 2_200_000, -1_000_000, epsg3577)
+
+    # the whole globe covers the extent, so its projection has to cover it too
+    out = geom.project_to_extent(geom.box(-180, -90, 180, 90, epsg4326), extent)
+    assert out.crs == epsg3577
+    assert out.area / extent.area > 0.999
+
+    # ... a region on the far side of the planet does not
+    assert geom.project_to_extent(geom.box(-80, 20, -70, 30, epsg4326), extent).is_empty
+
+    # a query well inside the safe region keeps its shape, just sampled more finely
+    local = geom.box(130, -30, 140, -20, epsg4326)
+    out = geom.project_to_extent(local, extent)
+    assert out.crs == epsg3577
+    assert out.area == approx(local.to_crs(epsg3577).area, rel=0.01)
+    assert count_coordinates(out) > count_coordinates(local.to_crs(epsg3577))
+
+    assert geom.project_to_extent(extent, extent) is extent
+    with pytest.raises(ValueError):
+        geom.project_to_extent(geom.box(0, 0, 1, 1, None), extent)
+
+
 def test_unary_union() -> None:
     box1 = geom.box(10, 10, 30, 30, crs=epsg4326)
     box2 = geom.box(20, 10, 40, 30, crs=epsg4326)

--- a/tests/test_gridspec.py
+++ b/tests/test_gridspec.py
@@ -9,7 +9,7 @@ import numpy
 import pytest
 from pytest import approx
 
-from odc.geo import CRS, res_, resyx_, xy_, yx_
+from odc.geo import CRS, geom, res_, resyx_, xy_, yx_
 from odc.geo.geom import polygon
 from odc.geo.gridspec import GridSpec
 from odc.geo.testutils import SAMPLE_WKT_WITHOUT_AUTHORITY
@@ -138,3 +138,21 @@ def test_geojson() -> None:
     gs = GridSpec(crs, (10, 10), resolution=6_378_137 * 2 * math.pi)
     gjson = gs.geojson()
     assert len(gjson["features"]) > 0
+
+
+def test_tiles_from_geopolygon_cross_projection() -> None:
+    # projecting only the corners of the query makes the shape a chord approximation of
+    # the real footprint, which both misses and invents tiles (#87)
+    gs = GridSpec("epsg:3577", (1000, 1000), 1000)  # 1000km tiles
+
+    aus = geom.box(100, -45, 160, -10, "epsg:4326")
+    local = geom.box(130, -30, 140, -20, "epsg:4326")
+    assert local.within(aus)
+
+    tiles_aus = {idx for idx, _ in gs.tiles_from_geopolygon(aus)}
+    tiles_local = {idx for idx, _ in gs.tiles_from_geopolygon(local)}
+    assert tiles_local <= tiles_aus
+
+    # every tile handed back really does overlap the query
+    for idx, gbox in gs.tiles_from_geopolygon(aus):
+        assert not gbox.footprint("epsg:4326").disjoint(aus), idx


### PR DESCRIPTION
`GeoboxTiles.tiles()` returns **0 tiles** for a whole-world query against a 1680-tile EPSG:3577 grid, while the Australian subset of that same box returns 1512 — a superset query yielding less than its subset (#87).

Cause: the query's *vertices* are projected and the bounding box of the result is used as if it bounded the projected *region*, which only holds while the transform is near-affine over the query. The same line is in `range_from_bbox`, `GridSpec.tiles_from_geopolygon` and `GeoBox.from_geopolygon`, and it bites well short of "global" — a plain continental box drops 151 of 1663 tiles with no warning, and some UTM grids raise `Points of LinearRing do not form a closed linestring`.

Fix: densify before projecting, and clip the query to the target region when the destination CRS cannot represent it (lossless, since these callers only want the overlap with that region anyway). That needed the densification fixed first: `densify()` compared `x1**2 + x2**2` against `resolution**2` instead of the squared segment length, so a long segment near `x=0` was never split at any resolution, and a non-positive step never terminated — which `_auto_resolution()` returned for any zero-area geometry, so `to_crs(resolution="auto")` hung on a LineString.

Checked against a tile-by-tile oracle that projects each tile the other way (small, safe direction) and intersects in EPSG:4326, over 77 grid/query pairs across 7 CRSs: missing tiles 11087 → 0, spurious 3620 → 117, crashes 12 → 0. The remaining 117 are all on pole-covering grids, where a lon/lat box has no faithful image at all and over-selecting is the safe side; web mercator was already exact and stays exact. Full suite passes, and `densify()` no longer calls into shapely per point (~11x faster), which keeps timings within noise of before.

This is the narrower half of #87 — the existing call sites made robust, not the general-purpose robust `to_crs` for polygons you describe there. Happy to make `project_to_extent` private if you'd rather not commit to the name.
