### PR TITLE
fix: densify measured |p1|² + |p2|² instead of the segment distance

### DIFF
--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -458,10 +458,14 @@ def densify(
     """
     Adds points so they are at most `resolution` units apart.
     """
+    if len(coords) == 0:
+        return []
+    assert resolution > 0
+
     d2 = resolution**2
 
     def short_enough(p1, p2):
-        return (p1[0] ** 2 + p2[0] ** 2) < d2
+        return ((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2) < d2
 
     new_coords: List[Tuple[float, float]] = [cast(Tuple[float, float], coords[0])]
     for p1, p2 in zip(coords[:-1], coords[1:]):
@@ -1532,4 +1536,9 @@ def count_coordinates(g: Geometry | Iterable[Geometry] | BoundingBox) -> int:
 
 def _auto_resolution(g: Geometry) -> float:
     # aim for ~100 points per side of a square
-    return math.sqrt(g.area) * 4 / 100
+    if g.area > 0:
+        return math.sqrt(g.area) * 4 / 100
+    # zero-area inputs (lines, degenerate polygons) still need densifying,
+    # fall back to the extent
+    bbox = g.boundingbox
+    return max(bbox.span_x, bbox.span_y) / 25

--- a/odc/geo/geom.py
+++ b/odc/geo/geom.py
@@ -460,7 +460,13 @@ def densify(
     """
     if len(coords) == 0:
         return []
-    assert resolution > 0
+    if resolution <= 0:
+        # A degenerate (zero-extent) geometry legitimately produces resolution=0
+        # via callers that auto-derive it from a bounding-box span (e.g. a single
+        # point or an empty GeoBox slice). There is nothing to subdivide by, and
+        # looping with a non-positive step would never terminate, so leave the
+        # coordinates as-is instead.
+        return [cast(Tuple[float, float], p) for p in coords]
 
     d2 = resolution**2
 
@@ -1535,10 +1541,13 @@ def count_coordinates(g: Geometry | Iterable[Geometry] | BoundingBox) -> int:
 
 
 def _auto_resolution(g: Geometry) -> float:
-    # aim for ~100 points per side of a square
+    # aim for ~100 points per side of a square. Not a precision guard: area is
+    # never negative, this just tells apart a genuinely 2D geometry from a
+    # degenerate one (line, point, sliver polygon) where sqrt(area) is a poor
+    # resolution estimate (0 for a point/line, near-0 for a thin polygon).
     if g.area > 0:
         return math.sqrt(g.area) * 4 / 100
-    # zero-area inputs (lines, degenerate polygons) still need densifying,
-    # fall back to the extent
+    # fall back to the bounding-box extent; can still be 0 for a single point,
+    # which densify() now tolerates instead of asserting.
     bbox = g.boundingbox
     return max(bbox.span_x, bbox.span_y) / 25

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -401,6 +401,44 @@ def test_densify() -> None:
     assert densify(s_x10, 5) == [(0, 0), (5, 0), (10, 0)]
     assert densify(s_x10, 4) == [(0, 0), (4, 0), (8, 0), (10, 0)]
 
+    # the "is this segment already short enough" test has to measure the segment, a
+    # long one is not exempt just because its endpoints sit near x=0
+    for coords in (
+        [(0.1, -80.0), (0.1, 80.0)],
+        [(50.0, -80.0), (50.0, 80.0)],
+        [(-80.0, 0.1), (80.0, 0.1)],
+        [(0.0, 0.0), (0.0, 5.0), (10.0, 5.0)],
+        [(0.0, 0.0), (15.0, 0.0)],
+    ):
+        pts = densify(coords, 10)
+        assert max(math.dist(a, b) for a, b in zip(pts[:-1], pts[1:])) <= 10 + 1e-9
+
+    # a non-positive step would make the interpolation loop non-terminating
+    with pytest.raises(AssertionError):
+        densify(s_x10, 0)
+    with pytest.raises(AssertionError):
+        densify(s_x10, -1)
+    assert densify([], 1) == []
+
+
+def test_segmented_zero_area() -> None:
+    # resolution="auto" was derived from area, which is 0 for anything 1-D, and a
+    # zero step never terminated
+    ll = geom.line([(0.0, -80.0), (0.0, 80.0)], epsg4326)
+    assert len(ll.segmented(10).geom.coords) == 17
+    assert len(ll.to_crs(epsg3857, resolution="auto").geom.coords) > 2
+
+    sliver = geom.polygon([(1, 1), (2, 2), (3, 3), (1, 1)], crs=epsg4326)
+    assert sliver.to_crs(epsg3857, resolution="auto").is_empty is False
+
+    pt = geom.point(10, 20, epsg4326)
+    assert pt.to_crs(epsg3857, resolution="auto").geom.geom_type == "Point"
+    assert (
+        geom.Geometry({"type": "Polygon", "coordinates": []}, epsg4326)
+        .to_crs(epsg3857, resolution="auto")
+        .is_empty
+    )
+
 
 def test_unary_union() -> None:
     box1 = geom.box(10, 10, 30, 30, crs=epsg4326)

--- a/tests/test_geom.py
+++ b/tests/test_geom.py
@@ -413,12 +413,28 @@ def test_densify() -> None:
         pts = densify(coords, 10)
         assert max(math.dist(a, b) for a, b in zip(pts[:-1], pts[1:])) <= 10 + 1e-9
 
-    # a non-positive step would make the interpolation loop non-terminating
-    with pytest.raises(AssertionError):
-        densify(s_x10, 0)
-    with pytest.raises(AssertionError):
-        densify(s_x10, -1)
+    # a non-positive step would make the interpolation loop non-terminating; a degenerate
+    # (zero-extent) geometry legitimately derives resolution=0 from its own bounding box
+    # (e.g. GeoBox._reproject_resolution, ui.py's outline()), so leave coords unchanged
+    # rather than raising.
+    assert densify(s_x10, 0) == s_x10
+    assert densify(s_x10, -1) == s_x10
     assert densify([], 1) == []
+    assert densify([], 0) == []
+
+
+def test_reproject_zero_extent_geobox() -> None:
+    # a GeoBox with a zero-size shape has a zero-span bounding box in both axes, so
+    # _reproject_resolution derives resolution=0 -- densify must not raise on that.
+    from odc.geo import wh_
+    from odc.geo.geobox import GeoBox
+
+    gbox = GeoBox.from_bbox([0, 0, 20, 10], "epsg:3857", shape=wh_(200, 100))
+    empty = gbox[:0, :0]
+    assert empty.extent.boundingbox.span_x == 0
+    assert empty.extent.boundingbox.span_y == 0
+    assert empty.footprint("epsg:4326").geom_type == "Polygon"
+    assert isinstance(empty._repr_html_(), str)
 
 
 def test_segmented_zero_area() -> None:


### PR DESCRIPTION
densify's `short_enough` predicate measured `p1[0]**2 + p2[0]**2` instead of the squared segment distance, so long segments whose endpoints sit near zero were treated as already fine and never densified. It now measures the actual segment. Empty and non-positive-`resolution` inputs are guarded (they used to spin forever), and `resolution="auto"` falls back to the extent for zero-area geometries. This is the densify part of #306, split out as discussed.